### PR TITLE
Add economist-style plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,7 +95,7 @@
     {
       "name": "ultrathink",
       "source": "./plugins/ultrathink",
-      "description": "Use /ultrathink <TASK_DESCRIPTION> to launch a Coordinator Agent that directs four specialist sub-agents\u2014Architect, Research, Coder, and Tester\u2014to analyze, design, implement, and validate your coding task. The process breaks the task into clear steps, gathers insights, and synthesizes a cohesive solution with actionable outputs. Relevant files can be referenced ad-hoc using @ filename syntax.",
+      "description": "Use /ultrathink <TASK_DESCRIPTION> to launch a Coordinator Agent that directs four specialist sub-agents—Architect, Research, Coder, and Tester—to analyze, design, implement, and validate your coding task. The process breaks the task into clear steps, gathers insights, and synthesizes a cohesive solution with actionable outputs. Relevant files can be referenced ad-hoc using @ filename syntax.",
       "version": "1.0.0",
       "author": {
         "name": "Jeronim Morina"
@@ -869,7 +869,7 @@
       "description": "Use this agent when setting up CI/CD pipelines, configuring Docker containers, deploying applications to cloud platforms, setting up Kubernetes clusters, implementing infrastructure as code, or automating deployment workflows. Examples: <example>Context: User is setting up a new project and needs deployment automation. user: \"I've built a FastAPI application and need to deploy it to production with proper CI/CD\" assistant: \"I'll use the deployment-engineer agent to set up a complete deployment pipeline with Docker, GitHub Actions, and production-ready configurations.\"</example> <example>Context: User mentions containerization or deployment issues. user: \"Our deployment process is manual and error-prone. We need to automate it.\" assistant: \"Let me use the deployment-engineer agent to design an automated CI/CD pipeline that eliminates manual steps and ensures reliable deployments.\"</example>",
       "version": "1.0.0",
       "author": {
-        "name": "Jure \u0160uni\u0107"
+        "name": "Jure Šunić"
       },
       "category": "agents",
       "homepage": "https://claudecodecommands.directory/agents/deployment-engineer",
@@ -1163,7 +1163,7 @@
       "description": "Use this agent when you need to design, build, or validate n8n automation workflows. This agent specializes in creating efficient n8n workflows using proper validation techniques and MCP tools integration.\\n\\nExamples:\\n- <example>\\n  Context: User wants to create a Slack notification workflow when a new GitHub issue is created.\\n  user: \"I need to create an n8n workflow that sends a Slack message whenever a new GitHub issue is opened\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to design and build this GitHub-to-Slack automation workflow with proper validation.\"\\n  <commentary>\\n  The user needs n8n workflow creation, so use the n8n-workflow-builder agent to handle the complete workflow design, validation, and deployment process.\\n  </commentary>\\n</example>\\n- <example>\\n  Context: User has an existing n8n workflow that needs debugging and optimization.\\n  user: \"My n8n workflow keeps failing at the HTTP Request node, can you help me fix it?\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to analyze and debug your workflow, focusing on the HTTP Request node configuration.\"\\n  <commentary>\\n  Since this involves n8n workflow troubleshooting and validation, use the n8n-workflow-builder agent to diagnose and fix the issue.\\n  </commentary>\\n</example>\\n- <example>\\n  Context: User wants to understand n8n best practices and available nodes for a specific use case.\\n  user: \"What are the best n8n nodes for processing CSV data and sending email reports?\"\\n  assistant: \"I'll use the n8n-workflow-builder agent to explore the available nodes and recommend the best approach for CSV processing and email automation.\"\\n  <commentary>\\n  This requires n8n expertise and node discovery, so use the n8n-workflow-builder agent to provide comprehensive guidance.\\n  </commentary>\\n</example>",
       "version": "1.0.0",
       "author": {
-        "name": "Jure \u0160uni\u0107"
+        "name": "Jure Šunić"
       },
       "category": "agents",
       "homepage": "https://claudecodecommands.directory/agents/n8n-workflow-builder",
@@ -1219,7 +1219,7 @@
       "description": "Use this agent when you need to create comprehensive Product Requirements Documents (PRDs) that combine business strategy, technical architecture, and user research. Examples: <example>Context: The user needs to create a PRD for a new feature or product launch. user: \"I need to create a PRD for our new user authentication system that will support SSO and multi-factor authentication\" assistant: \"I'll use the prd-specialist agent to create a comprehensive PRD that covers the strategic foundation, technical requirements, and implementation blueprint for your authentication system.\"</example> <example>Context: The user is planning a major product initiative and needs strategic documentation. user: \"We're launching a mobile app for our e-commerce platform and need a detailed PRD to guide development\" assistant: \"Let me engage the prd-specialist agent to develop a thorough PRD that includes market analysis, user research integration, technical architecture, and implementation roadmap for your mobile app initiative.\"</example>",
       "version": "1.0.0",
       "author": {
-        "name": "Jure \u0160uni\u0107"
+        "name": "Jure Šunić"
       },
       "category": "agents",
       "homepage": "https://claudecodecommands.directory/agents/prd-specialist",
@@ -1303,7 +1303,7 @@
       "description": "Use this agent when working with Python code that requires advanced features, performance optimization, or comprehensive refactoring. Examples: <example>Context: User needs to optimize a slow Python function that processes large datasets. user: \"This function is taking too long to process our data, can you help optimize it?\" assistant: \"I'll use the python-expert agent to analyze and optimize your Python code with advanced techniques and performance profiling.\"</example> <example>Context: User wants to implement async/await patterns in their existing synchronous Python code. user: \"I need to convert this synchronous code to use async/await for better performance\" assistant: \"Let me use the python-expert agent to refactor your code with proper async/await patterns and concurrent programming techniques.\"</example> <example>Context: User needs help implementing complex Python design patterns. user: \"I want to implement a factory pattern with decorators for my API endpoints\" assistant: \"I'll use the python-expert agent to implement advanced Python patterns with decorators and proper design principles.\"</example>",
       "version": "1.0.0",
       "author": {
-        "name": "Jure \u0160uni\u0107"
+        "name": "Jure Šunić"
       },
       "category": "agents",
       "homepage": "https://claudecodecommands.directory/agents/python-expert",
@@ -1718,6 +1718,24 @@
         "kanban",
         "productivity",
         "templates"
+      ]
+    },
+    {
+      "name": "economist-style",
+      "source": "./plugins/economist-style",
+      "description": "Apply The Economist style guide to written content - clarity, precision, brevity, dialect-aware. Unofficial; not affiliated with The Economist",
+      "version": "1.4.2",
+      "author": {
+        "name": "Tom Dickson",
+        "url": "https://github.com/TAJD"
+      },
+      "category": "writing",
+      "homepage": "https://github.com/TAJD/economist-style-guide-plugin",
+      "keywords": [
+        "style-guide",
+        "writing",
+        "editing",
+        "proofreading"
       ]
     }
   ]

--- a/plugins/economist-style/.claude-plugin/plugin.json
+++ b/plugins/economist-style/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "economist-style",
+  "description": "Apply The Economist style guide to written content - clarity, precision, brevity, dialect-aware",
+  "version": "1.4.2",
+  "author": {
+    "name": "Tom Dickson"
+  },
+  "homepage": "https://tom-dickson.com/blog/teaching-claude-economist-style/",
+  "repository": "https://github.com/TAJD/economist-style-guide-plugin",
+  "license": "MIT",
+  "keywords": [
+    "style-guide",
+    "writing",
+    "editing",
+    "economist",
+    "proofreading",
+    "documentation"
+  ]
+}

--- a/plugins/economist-style/README.md
+++ b/plugins/economist-style/README.md
@@ -1,0 +1,191 @@
+# Economist Style Guide Plugin for Claude Code
+
+Apply The Economist's editorial standards to your writing - clarity, precision, brevity and dialect-aware editing.
+
+> This is an independent project, not affiliated with or endorsed by The Economist.
+
+## Features
+
+- **Automatic activation**: Claude applies style guidance when you edit markdown, HTML, or documentation
+- **Progressive disclosure**: Loads detailed rules only when needed
+- **Weasel word detection**: Identifies vague language and suggests specifics
+- **Filler removal**: Flags redundant phrases and empty intensifiers
+- **Dialect-aware**: Matches document's existing conventions (British, American, etc.)
+- **Passive voice detection**: Suggests active voice alternatives
+
+## Installation
+
+### Via Local Marketplace (Development)
+
+```bash
+# Create test marketplace directory
+mkdir -p ~/economist-style-marketplace/.claude-plugin
+cd ~/economist-style-marketplace
+
+# Copy this plugin
+cp -r /path/to/economist-style-plugin .
+
+# Create marketplace.json
+cat > .claude-plugin/marketplace.json << 'EOF'
+{
+  "name": "economist-style-marketplace",
+  "owner": {
+    "name": "Your Name"
+  },
+  "plugins": [
+    {
+      "name": "economist-style",
+      "source": "./economist-style-plugin",
+      "description": "Apply The Economist style guide to written content"
+    }
+  ]
+}
+EOF
+
+# Start Claude Code and install
+claude
+/plugin marketplace add ~/economist-style-marketplace
+/plugin install economist-style@economist-style-marketplace
+```
+
+### Via Git Repository (Production)
+
+Once published to a Git repository:
+
+```bash
+/plugin marketplace add your-username/economist-style-plugins
+/plugin install economist-style@economist-style-plugins
+```
+
+## Usage
+
+### Automatic Application
+
+The skill activates automatically when you work with text:
+
+```bash
+# Just ask Claude to edit your content
+"Please review this markdown file for style issues"
+"Fix the grammar in this document"
+"Edit this for clarity and precision"
+```
+
+Claude will apply Economist style principles automatically.
+
+## What Gets Checked
+
+### Clarity
+- Passive voice → Active voice
+- Complex words → Simple alternatives
+- Jargon → Plain English
+- Hedge words → Direct statements
+
+### Precision
+- Vague quantifiers → Specific numbers
+- Weasel words → Evidence-based claims
+- Filler phrases → Deletion
+- Redundancies → Concise expressions
+
+### Dialect Consistency
+- Detects document's existing conventions (British, American, etc.)
+- Only flags inconsistencies within the same document
+- Matches spelling patterns (-ise vs -ize)
+- Preserves established style
+
+### Common Errors
+- Affect/effect confusion
+- Less/fewer mistakes
+- That/which usage
+- Split infinitives (when awkward)
+- Dangling modifiers
+
+## File Types Supported
+
+- **Markdown**: `.md`, `.markdown`
+- **HTML**: `.html`, `.htm`
+- **Code documentation**: Python, JavaScript, TypeScript, Java, C/C++ (comments and docstrings)
+- **Plain text**: `.txt`
+
+## Examples
+
+### Before
+```
+The data was analyzed by the research team and it was found that 
+there was a significant increase in sales. Many customers responded 
+positively to the new program.
+```
+
+### After
+```
+The research team analyzed the data and found sales rose 
+[specify: by how much?]. Customers responded positively to 
+the new program.
+```
+
+### Changes Made
+1. ✓ Passive → active voice
+2. ✓ "significant increase" → flagged for a specific figure (the editor asks; it never invents numbers)
+3. ✓ "Many" → deleted (vague quantifier)
+4. ✓ "it was found that there were" → reduced (brevity)
+5. ✓ Dialect preserved: kept "analyzed" and "program" (American English)
+
+## Plugin Structure
+
+```
+economist-style/
+├── .claude-plugin/
+│   └── plugin.json              # Plugin metadata
+├── skills/
+│   └── economist-style/
+│       ├── SKILL.md             # Main skill instructions
+│       └── reference/
+│           ├── ECONOMIST-SIGNATURE.md  # One-page distillation of house style
+│           ├── CLARITY.md       # Passive voice, jargon, complexity
+│           ├── PRECISION.md     # Weasel words, fillers, clichés
+│           ├── WORDS.md         # A-Z rulings on misused words
+│           ├── DIALECT-CONVENTIONS.md  # British/American conventions
+│           ├── COMMON-ERRORS.md # Frequent mistakes, sensitivity
+│           ├── PUNCTUATION.md   # Commas, dashes, quotation marks
+│           ├── NUMBERS.md       # Numerals, percentages, dates
+│           ├── STRUCTURE.md     # Paragraphs, leads, conclusions
+│           ├── TONE.md          # Voice, register, adjective restraint
+│           ├── ABBREVIATIONS.md # Acronyms, Latin terms
+│           ├── CAPITALIZATION.md # Titles, institutions, geographic
+│           └── SPECIAL-CONTEXTS.md # Foreign words, quotations, lists
+└── README.md
+```
+
+## Contributing
+
+Improvements welcome! Focus areas:
+
+- Additional dialect-specific terminology
+- More weasel word patterns
+- Industry-specific style guides (tech, finance, etc.)
+- Additional file type support
+
+## References
+
+- *The Economist Style Guide* (12th edition, Profile Books, 2018) — the authoritative source; the Economist's free online style guide has been taken down
+- [Claude Code Documentation](https://code.claude.com/docs)
+- [More about the implementation](https://tom-dickson.com/blog/teaching-claude-economist-style/)
+
+## License
+
+MIT License - feel free to adapt for your organisation's style guide.
+
+## Version
+
+1.4.2 - Paraphrased the duplicate Orwell quotation in PRECISION.md, replaced source-derived name examples, added non-affiliation disclaimers
+
+1.4.1 - Added Orwell's six elementary rules to SKILL.md (verified against the style guide's introduction)
+
+1.4.0 - Added ECONOMIST-SIGNATURE.md quick reference (loaded first), WORDS.md A-Z usage rulings, honorifics convention (Mr/Ms + surname after first mention), and a clichés/dead-metaphors check; housekeeping on installation docs
+
+1.3.0 - Corrected rules against the official Economist Style Guide (11th edition): number spell-out cutoff (one to ten), date format (January 1st 2025), no serial comma, double quotation marks, co-operate/co-ordinate hyphenation, singular collective nouns, sentence-case headlines; relabelled general inclusive-language guidance that is not Economist doctrine
+
+1.2.0 - Added punctuation, numbers, structure, tone, abbreviations, capitalization, special contexts, gender-neutral language, and sensitivity guidelines
+
+## Author
+
+Tom Dickson

--- a/plugins/economist-style/skills/economist-style/SKILL.md
+++ b/plugins/economist-style/skills/economist-style/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: economist-style
+description: Apply The Economist style guide to written content. Use when editing markdown, HTML, documentation, or any written text that needs professional editing for clarity, precision, and brevity. Detects weasel words, fillers, passive voice, and style issues.
+---
+
+# The Economist Style Guide
+
+Apply these principles to all written content, including markdown files, HTML, code documentation, and technical writing.
+
+## Core Principles
+
+1. **Clarity first**: Use short words, active voice, and concrete examples
+2. **Precision**: Replace vague quantifiers with specific numbers and facts
+3. **Brevity**: Choose concise over verbose expressions
+4. **Dialect awareness**: Match the document's existing spelling and conventions (British, American, etc.)
+
+## Orwell's Six Elementary Rules
+
+The guide's introduction rests on George Orwell's six rules (from "Politics and the English Language", 1946): clarity of thought first, then say it as simply as possible.
+
+1. Never use a metaphor, simile or other figure of speech which you are used to seeing in print
+2. Never use a long word where a short one will do
+3. If it is possible to cut out a word, always cut it out
+4. Never use the passive where you can use the active
+5. Never use a foreign phrase, a scientific word or a jargon word if you can think of an everyday English equivalent
+6. Break any of these rules sooner than say anything outright barbarous
+
+## Tone: The "Do Nots"
+
+In the spirit of the guide's introduction:
+
+- **Do not be stuffy**: Use everyday speech, not the language of lawyers or bureaucrats
+- **Do not be hectoring or arrogant**: Those who disagree are not necessarily stupid; persuade with evidence, not assertion
+- **Do not be too pleased with yourself**: Let analysis speak; avoid self-congratulation
+- **Do not be too chatty**: Maintain professional distance
+- **Do not be too didactic**: Guide, don't lecture
+- **Get straight in and be lucid**: No throat-clearing openings; edit ruthlessly; cut anything superfluous
+
+## Analysis Workflow
+
+When reviewing text, follow this sequence:
+
+### 0. Load the Signature Rules
+Read `reference/ECONOMIST-SIGNATURE.md` first — a one-page distillation of the rules that make copy recognizably Economist (numbers, dates, commas, quotes, honorifics, headings). Most reviews need only this plus the quick checks below; load the detailed files only when a deeper check is warranted.
+
+### 1. Detect Document Dialect
+**IMPORTANT**: Before making any suggestions, detect the document's existing spelling dialect:
+- Look for spellings like "colour" vs "color", "organise" vs "organize"
+- Check date formats (1st January vs January 1st)
+- Observe punctuation style (single vs double quotes)
+- **Match the document's existing conventions** - do not impose a dialect
+
+### 2. Structural Review
+- Check for buried ledes (main point should come first)
+- Verify logical flow and argument structure
+- Ensure each paragraph has a clear purpose
+
+### 3. Clarity Analysis
+For detailed passive voice and clarity rules, read `reference/CLARITY.md`
+
+Quick checks:
+- Flag passive voice constructions
+- Identify jargon and suggest plain alternatives
+- Find unnecessarily complex words
+- Detect hedge words that weaken statements
+
+### 4. Precision Check
+For detailed precision rules, read `reference/PRECISION.md`
+
+Quick checks:
+- Identify vague quantifiers ("many", "often", "significant")
+- Flag weasel words and empty fillers
+- Flag clichés and dead metaphors ("game-changer", "perfect storm")
+- Suggest specific numbers or evidence
+- Remove redundant phrases
+
+### 5. Dialect Conventions (if applicable)
+Only if the user explicitly requests dialect checking, or if there are inconsistencies within the document, read `reference/DIALECT-CONVENTIONS.md`
+
+### 6. Common Errors
+For frequently encountered mistakes, read `reference/COMMON-ERRORS.md`
+
+### 7. Punctuation Check
+For detailed punctuation rules (commas, semicolons, dashes, quotation marks), read `reference/PUNCTUATION.md`
+
+Quick checks:
+- Verify comma usage (serial comma, restrictive clauses)
+- Check dash and hyphen usage
+- Ensure consistent quotation mark style
+
+### 8. Numbers and Figures
+For number formatting guidelines, read `reference/NUMBERS.md`
+
+Quick checks:
+- Spell out numbers one to ten, use numerals from 11
+- Verify percentage formatting (% symbol, percentage points vs percentages)
+- Check date and currency formatting
+
+### 9. Structure Review
+For document organisation guidelines, read `reference/STRUCTURE.md`
+
+Quick checks:
+- Each paragraph has a clear topic sentence
+- Lead/opening hooks the reader
+- Logical flow from paragraph to paragraph
+- Conclusion adds value (not just summary)
+
+### 10. Tone Assessment
+For voice and register guidance, read `reference/TONE.md`
+
+Quick checks:
+- Authoritative but not arrogant
+- Avoid excessive adjectives and intensifiers
+- Neutral language on contested issues
+- No preaching or lecturing
+- People: full name on first mention, honorific + surname after ("Ms Yellen")
+
+### 11. Abbreviations (on-demand)
+If the document contains abbreviations or acronyms, read `reference/ABBREVIATIONS.md`
+
+### 12. Capitalisation (on-demand)
+If there are capitalisation questions (titles, institutions, geographic terms), read `reference/CAPITALIZATION.md`
+
+### 13. Special Contexts (on-demand)
+For quotations, foreign words, lists, or tables, read `reference/SPECIAL-CONTEXTS.md`
+
+### 14. Word Usage (on-demand)
+For rulings on commonly misused words (aggravate, decimate, refute, unique...), read `reference/WORDS.md`
+
+## Output Format
+
+When providing feedback:
+
+1. List issues by category (clarity, precision, dialect consistency if applicable)
+2. Provide line/paragraph references
+3. Show original text and suggested replacement
+4. Explain the reasoning briefly
+
+Example:
+```
+**Clarity Issue** (Para 2, Line 3)
+Original: "The data was analysed by the research team"
+Suggested: "The research team analysed the data"
+Reason: Active voice is clearer and more direct
+```
+
+## When Not to Apply
+
+- Direct quotations (preserve original wording)
+- Code examples (unless in comments/documentation)
+- Technical terms with no plain alternative
+- Proper nouns and brand names
+- Established dialect/spelling patterns (match what's already there)

--- a/plugins/economist-style/skills/economist-style/reference/ABBREVIATIONS.md
+++ b/plugins/economist-style/skills/economist-style/reference/ABBREVIATIONS.md
@@ -1,0 +1,190 @@
+# Abbreviations and Acronyms Guidelines
+
+Use abbreviations to aid readability, not to show off knowledge. Every abbreviation should be clear to your audience.
+
+## General Principles
+
+### Spell Out on First Mention
+Most abbreviations should be spelled out on first use, with the abbreviation in parentheses:
+- "The International Monetary Fund (IMF) said..."
+- "Gross domestic product (GDP) grew by 2%"
+
+### When to Skip the Spell-Out
+Some abbreviations are better known than their full forms. Don't spell out:
+- Common units: kg, km, mph
+- Well-known organisations: BBC, FBI, NASA, UN
+- Technical terms in specialist publications where readers know them
+
+### Test for Familiarity
+Ask: Would my reader recognise this abbreviation without explanation?
+- General audience: Fewer abbreviations, more spell-outs
+- Specialist audience: Common field abbreviations need no explanation
+
+## Acronyms and Initialisms
+
+### Acronyms (Pronounced as Words)
+Capitalise, no full stops:
+- NATO (not N.A.T.O.)
+- UNESCO
+- OPEC
+- Exception: radar, scuba and laser have become ordinary lowercase words
+
+### Initialisms (Pronounced Letter by Letter)
+Capitalise, no full stops:
+- FBI, CIA, BBC, UN
+- GDP, IMF, EU
+- CEO, CFO
+
+### Mixed Forms
+Some abbreviations have both:
+- FAQ (pronounced "fack" or "F-A-Q")
+- SQL (pronounced "sequel" or "S-Q-L")
+
+Use the most common pronunciation for your audience.
+
+## Formatting Rules
+
+### No Full Stops
+Do not use full stops in abbreviations:
+
+| Write | Not |
+|-------|-----|
+| GDP | G.D.P. |
+| Mr | Mr. |
+| Dr | Dr. |
+| St | St. (for Saint) |
+| kg | kg. |
+| etc | etc. |
+| ie | i.e. |
+| eg | e.g. |
+
+**Exceptions**: initials in people's and companies' names take points: "J.K. Rowling", "L.L. Bean". A comma follows "ie" ("ie, the largest firms").
+
+### Capitalisation
+- Most abbreviations: All caps (GDP, IMF, EU)
+- Lower case for units: kg, km, mb
+- Mixed case for some: kWh, PhD
+
+### Articles
+Use "a" or "an" based on pronunciation:
+- "An FBI agent" (sounds like "eff")
+- "A UN resolution" (sounds like "you")
+- "An IMF report" (sounds like "eye")
+
+## Latin Abbreviations
+
+### Common Latin Terms
+
+| Abbreviation | Meaning | Usage |
+|--------------|---------|-------|
+| ie | that is | Clarifies or restates: "The largest market, ie America" |
+| eg | for example | Introduces examples: "Major cities, eg London and Paris" |
+| etc | and so forth | Ends incomplete lists: "taxes, spending, etc" |
+| cf | compare | Cross-reference: "cf the earlier report" |
+| NB | note well | Draws attention: "NB: deadline is Friday" |
+| viz | namely | Lists specifics: "Two countries, viz France and Germany" |
+| vs | versus | Opposition: "Smith vs Jones" |
+
+### Usage Notes
+- **ie vs eg**: "ie" means "that is" (restates the same thing differently); "eg" means "for example" (gives instances)
+- **Avoid overuse**: Latin abbreviations can seem academic or pretentious. Use sparingly.
+- **Punctuation**: No commas after ie or eg unless your style guide requires them
+
+### When to Avoid
+Consider replacing Latin abbreviations with plain English:
+- "eg" → "such as" or "for example"
+- "ie" → "that is" or "in other words"
+- "etc" → "and so on" or "among others"
+
+## Plurals of Abbreviations
+
+### Standard Plurals
+Add lowercase "s", no apostrophe:
+- "MPs" (not "MP's")
+- "CEOs" (not "CEO's")
+- "GDPs of various countries"
+- "The 1990s" (not "1990's")
+
+### Exceptions
+Some abbreviations don't take plurals:
+- Units of measurement: "5 kg" not "5 kgs"
+- "Pp" for pages (or just "pages 1-10")
+
+## Abbreviations to Avoid
+
+### Overused Abbreviations
+Some abbreviations appear so often they lose meaning:
+
+| Tired | Alternative |
+|-------|-------------|
+| ASAP | Soon, by Friday, urgently |
+| TBD | Undecided, to be confirmed |
+| TBC | To be confirmed |
+| FYI | [Often unnecessary—just give the information] |
+
+### Jargon Abbreviations
+Avoid abbreviations that only insiders know:
+- Spell out industry-specific terms for general audiences
+- Consider whether the abbreviation helps or hinders clarity
+
+## Titles and Honorifics
+
+### Standard Forms
+No full stops:
+- Mr, Mrs, Ms, Dr, Prof
+- Jr, Sr
+
+### When to Use
+- First mention: Full name with title if relevant: "Dr Jane Smith"
+- Subsequently: Surname only: "Smith said..."
+- In quotes: Use the title the person prefers
+
+## Company and Organisation Names
+
+### Follow Their Style
+Use the organisation's preferred form:
+- eBay, iPhone, PayPal (respect capitalisation)
+- IBM, not I.B.M.
+
+### At Sentence Start
+Capitalise if needed for clarity:
+- "EBay announced..." (or rewrite to avoid)
+- "The company eBay announced..."
+
+## Geographic Abbreviations
+
+### Countries
+Spell out in running text:
+- "The United States" or "America", not "the US" (though US is acceptable as adjective: "US policy")
+- "The United Kingdom" or "Britain", not "the UK"
+
+In tables, charts, and addresses, abbreviations are acceptable:
+- US, UK, EU, UAE
+
+### States and Regions
+For US states:
+- Spell out in text: "California passed a law"
+- Abbreviate in addresses and data: CA, NY, TX
+
+## Technical Contexts
+
+### Science and Technology
+Define on first use unless writing for specialists:
+- "Artificial intelligence (AI)"
+- "Application programming interface (API)"
+
+### Financial Terms
+Common financial abbreviations:
+- P/E (price-to-earnings ratio)
+- ROI (return on investment)
+- IPO (initial public offering)
+- M&A (mergers and acquisitions)
+
+## Checklist
+
+- [ ] Is each abbreviation spelled out on first mention (unless universally known)?
+- [ ] Are abbreviations consistent throughout the document?
+- [ ] Have I avoided excessive abbreviations that make text hard to read?
+- [ ] Are plurals formed correctly (no apostrophes)?
+- [ ] Are articles (a/an) correct based on pronunciation?
+- [ ] Have I avoided jargon abbreviations for general audiences?

--- a/plugins/economist-style/skills/economist-style/reference/CAPITALIZATION.md
+++ b/plugins/economist-style/skills/economist-style/reference/CAPITALIZATION.md
@@ -1,0 +1,227 @@
+# Capitalisation Guidelines
+
+Capitalise sparingly. Overuse of capitals looks pompous and clutters the page. When in doubt, use lower case.
+
+## General Principle
+
+Capitalise proper nouns (specific names). Use lower case for common nouns (general categories).
+
+**Capitalise**: The Treasury, President Biden, the Sahara
+**Lower case**: the treasury department, the president, the desert
+
+## Job Titles
+
+### With Names
+Capitalise titles used directly before a name:
+- "President Biden announced..."
+- "Chancellor Scholz said..."
+- "Professor Smith argued..."
+
+### Without Names
+Use lower case for titles used generically or after a name:
+- "The president announced..." (referring to Biden)
+- "Joe Biden, the president, said..."
+- "The chancellor of Germany..."
+- "Angela Merkel, who was then chancellor..."
+
+### Common Titles
+
+| With name | Without name |
+|-----------|--------------|
+| Prime Minister Starmer | The prime minister |
+| Queen Elizabeth | The queen |
+| Pope Francis | The pope |
+| Dr Smith | The doctor |
+
+**Avoid false titles** for job descriptions: "Jerome Powell, chairman of the Federal Reserve", not "Chairman Powell".
+
+### Company Titles
+Use lower case for corporate titles:
+- "The chief executive of Apple..."
+- "Tim Cook, Apple's chief executive..."
+- "The company's chairman..."
+
+## Government and Institutions
+
+### Specific Institutions
+Capitalise the full official name:
+- "The House of Commons"
+- "The Supreme Court"
+- "The Federal Reserve"
+- "The European Commission"
+
+### Shortened References
+Use lower case when referring to an institution in shortened form:
+- "The Commons voted..." (but "the house voted" if meaning is clear)
+- "The court ruled..." (after first mention of Supreme Court)
+- "The Fed raised rates..." (acceptable as widely understood)
+- "The commission proposed..."
+
+### Generic References
+Lower case for generic institutional references:
+- "In parliament..."
+- "Central banks around the world..."
+- "The government announced..." (generic)
+
+### Specific vs Generic
+
+| Specific (capitalise) | Generic (lower case) |
+|-----------------------|----------------------|
+| The Senate | Senates around the world |
+| Congress | Parliamentary democracies |
+| The Cabinet | Cabinet ministers |
+| The Treasury | Treasury departments |
+
+## Political Terms
+
+### Parties and Movements
+Capitalise party names and formal movements:
+- "The Labour Party", "Labour"
+- "The Republican Party", "Republicans"
+- "The Green movement" (if referring to formal organisation)
+
+### Ideologies
+Lower case for ideologies:
+- "Conservative" (member of Conservative Party) vs "conservative" (ideology)
+- "Liberal" (member of Liberal Party) vs "liberal" (ideology)
+- "A socialist policy" (ideology)
+- "The Socialist Party" (organisation)
+
+### Political Terms
+
+| Capitalise | Lower case |
+|------------|------------|
+| The Tories | Tory policies |
+| Downing Street (the government) | The street |
+| The White House (the administration) | The white house (the building) |
+| The Democrats | Democratic policies |
+
+## Geographic Terms
+
+### Place Names
+Capitalise proper geographic names:
+- "The Pacific Ocean"
+- "The Sahara Desert"
+- "The Mississippi River"
+- "Central Park"
+
+### Regions
+Capitalise regions when they're proper names:
+- "The Middle East"
+- "South-East Asia"
+- "Central America"
+- "The West" (Western countries)
+- "The South" (American South)
+
+### Directions
+Lower case for directions:
+- "Travel north"
+- "The eastern part of the country"
+- "Western influence" (but "the West")
+
+### Geographic Adjectives
+
+| Proper name | Description |
+|-------------|-------------|
+| South Africa | Southern Africa (the region) |
+| North Korea | Northern England |
+| Western Europe (the region) | The western coast |
+
+## Historical Terms
+
+### Events and Periods
+Capitalise specific historical events and periods:
+- "The French Revolution"
+- "The Renaissance"
+- "The Cold War"
+- "The Great Depression"
+- "The Second World War" or "World War Two"
+
+### Generic Historical References
+Lower case for generic uses:
+- "The revolution changed France" (second reference)
+- "Various wars and depressions"
+- "A renaissance in the arts"
+
+## Organisations and Companies
+
+### Official Names
+Use the organisation's official capitalisation:
+- "Goldman Sachs"
+- "McKinsey & Company"
+- "eBay", "iPhone" (respect unconventional styling)
+
+### Descriptive References
+Lower case for descriptive terms:
+- "The bank" (after first mention)
+- "The firm announced..."
+- "The technology company..."
+
+## Headlines and Titles
+
+The Economist uses **sentence case**: capitalise only the first word and proper nouns:
+- "The rise and fall of economic theory"
+- "A new approach to climate policy"
+
+If the document already uses title case consistently, match it rather than converting — but prefer sentence case for new headings.
+
+## Religious Terms
+
+### Deities and Sacred Texts
+- "God" (when referring to the deity of monotheistic religions)
+- "The Bible", "The Quran", "The Torah"
+- "Allah", "Buddha", "Jesus Christ"
+
+### General Religious Terms
+Lower case for general terms:
+- "The church" (institution, lower case; "the Church of England" capitalised)
+- "Heaven and hell" (concepts)
+- "The archbishop said..." (title without name)
+
+## Brands and Trademarks
+
+### Trademarks
+Capitalise but avoid using as generic terms:
+- "Kleenex" → use "tissues"
+- "Google" → "search online" (unless specifically about Google)
+- "Xerox" → "photocopy"
+
+### When Necessary
+If you must use a brand name, capitalise:
+- "She searched on Google"
+- "The data was stored on Amazon Web Services"
+
+## Scientific Terms
+
+### Formal Names
+Capitalise:
+- Species names (first term only): *Homo sapiens*
+- Geological periods: The Jurassic period
+- Named laws and theories: lower case — "the theory of relativity", "Newton's laws of motion"
+
+### Common Terms
+Lower case for common scientific terms:
+- "Black holes", "quantum mechanics"
+- "Climate change", "global warming"
+- "The big bang" (though some capitalise)
+
+## Common Mistakes
+
+| Wrong | Correct |
+|-------|---------|
+| The Government | The government |
+| The Prime Minister said | The prime minister said |
+| Internet | internet |
+| Western Governments | Western governments |
+| Chief Executive Officer | chief executive |
+| Central Bank | central bank |
+| The North of England | the north of England |
+| Federal Government | federal government |
+
+## Checklist
+
+- [ ] Are job titles capitalised only with names?
+- [ ] Are institutions lower case on subsequent reference?
+- [ ] Are generic terms lower case?
+- [ ] Is capitalisation consistent throughout?
+- [ ] Have I avoided unnecessary capitals?

--- a/plugins/economist-style/skills/economist-style/reference/CLARITY.md
+++ b/plugins/economist-style/skills/economist-style/reference/CLARITY.md
@@ -1,0 +1,158 @@
+# Clarity Guidelines
+
+## Passive Voice
+
+The Economist strongly prefers active voice. Passive voice obscures who is responsible for actions.
+
+### Common Passive Patterns to Avoid
+
+- "was/were [verb]ed" → Active alternative
+- "has/have been [verb]ed" → Active alternative
+- "is/are being [verb]ed" → Active alternative
+
+### Examples
+
+**Weak (Passive)**:
+- "The report was published by the committee"
+- "Mistakes were made"
+- "It is believed that rates will rise"
+
+**Strong (Active)**:
+- "The committee published the report"
+- "We made mistakes" or "The team made mistakes"
+- "Economists believe rates will rise"
+
+### When Passive Voice is Acceptable
+
+- When the actor is unknown: "The building was constructed in 1843"
+- When the object is more important: "The president was assassinated"
+- Scientific writing when focusing on results: "The sample was heated to 100°C"
+
+## Jargon and Bureaucratese
+
+Replace technical jargon and business-speak with plain English.
+
+### Common Offenders
+
+| Jargon | Plain English |
+|--------|---------------|
+| utilise | use |
+| optimise | improve (unless genuine optimisation is meant) |
+| facilitate | help, enable |
+| implement | introduce, start |
+| leverage | use, exploit |
+| synergy | cooperation |
+| stakeholder | people affected, investors |
+| going forward | from now on, in future |
+| action (as verb) | do, carry out |
+| learnings | lessons |
+
+## Unnecessary Complexity
+
+Choose short, common words over long, uncommon ones.
+
+### Word Replacements
+
+| Complex | Simple |
+|---------|--------|
+| approximately | about |
+| commence | begin, start |
+| endeavour | try |
+| purchase | buy |
+| terminate | end |
+| in the event that | if |
+| prior to | before |
+| subsequent to | after |
+| in order to | to |
+| with regard to | about |
+
+## Hedge Words That Weaken Writing
+
+The Economist values confident, direct statements. Remove unnecessary hedging.
+
+### Common Hedges to Avoid
+
+- "It could be argued that..."
+- "To some extent..."
+- "It might be said that..."
+- "In a sense..."
+- "Arguably..."
+- "Possibly..."
+- "Perhaps..."
+
+### When Hedging is Appropriate
+
+- Genuine uncertainty about facts
+- Academic or scientific caution
+- Diplomatic language when discussing controversial topics
+
+### Better Alternatives
+
+Instead of: "It could be argued that inflation is rising"
+Write: "Inflation is rising" (if it's a fact)
+Or: "Some economists argue inflation is rising" (if it's a viewpoint)
+
+## Sentence Length
+
+- Aim for average sentence length of 15-20 words
+- Vary sentence length for rhythm
+- Break up sentences over 25 words unless there's a good reason
+- One idea per sentence
+
+## Paragraph Structure
+
+- Start with the main point (topic sentence)
+- Supporting evidence follows
+- Each paragraph should advance the argument
+- Typical paragraph: 3-5 sentences
+
+## The Conversational Test
+
+Ask yourself: "Would I use this word talking to a friend?"
+
+| Formal | Conversational |
+|--------|----------------|
+| obtain | get |
+| manufacture | make |
+| relinquish | give up |
+| ascertain | find out |
+| sufficient | enough |
+| additional | more |
+| regarding | about |
+| numerous | many |
+| utilise | use |
+| demonstrate | show |
+
+## Americanisms to Avoid
+
+**Apply only in British-dialect documents.** In a document written in American English, these expressions are fine — match the document.
+
+The Economist flags these American expressions:
+
+| Avoid | Use Instead |
+|-------|-------------|
+| meet with | meet |
+| outside of | outside |
+| figure out | work out |
+| deliver on (a promise) | keep |
+| reach out to | contact |
+| consult with | consult |
+| protest (transitive) | protest against |
+| appeal (a decision) | appeal against |
+| write (someone) | write to |
+
+## Inclusive Language
+
+Prefer gender-neutral terms where natural:
+
+| Avoid | Use Instead |
+|-------|-------------|
+| man-made | artificial, synthetic |
+| manpower | workforce, staff |
+| fireman | firefighter |
+| policeman | police officer |
+| stewardess | flight attendant |
+
+**Note**: The Economist itself retains "chairman" (it dislikes "chair" and "chairperson" for people) and does not ban "mankind". Treat those substitutions as general modern practice, not Economist style — follow the document's existing usage.
+
+Respect individuals' preferred pronouns and avoid stereotyping groups.

--- a/plugins/economist-style/skills/economist-style/reference/COMMON-ERRORS.md
+++ b/plugins/economist-style/skills/economist-style/reference/COMMON-ERRORS.md
@@ -1,0 +1,389 @@
+# Common Style Errors
+
+## Frequently Confused Words
+
+### Affect vs Effect
+
+**Affect** (verb): to influence
+- Higher rates affect growth
+- The policy affects consumers
+
+**Effect** (noun): a result
+- The effect was immediate
+- The policy had little effect
+
+**Effect** (verb - rare): to bring about
+- The reforms effected major change
+
+### Comprise vs Compose
+
+**Comprise**: consists of, includes (whole comprises parts)
+- The UK comprises England, Scotland, Wales and Northern Ireland
+- ❌ is comprised of (incorrect - avoid)
+
+**Compose**: make up (parts compose whole)
+- England, Scotland, Wales and Northern Ireland compose the UK
+
+**Better**: Use "consists of" or "is made up of" to avoid confusion
+- The UK consists of four nations
+
+### Imply vs Infer
+
+**Imply**: suggest indirectly (speaker/writer does this)
+- The data imply rates will rise
+- She implied that costs would increase
+
+**Infer**: deduce from evidence (reader/listener does this)
+- From the data, we infer rates will rise
+- Readers may infer different meanings
+
+### Less vs Fewer
+
+**Fewer**: countable items
+- fewer people, fewer companies, fewer votes
+
+**Less**: uncountable quantities
+- less money, less time, less growth
+
+**Common error**:
+- ❌ less people → ✓ fewer people
+- ❌ less companies → ✓ fewer companies
+
+### That vs Which
+
+**That**: defining clause (no comma)
+- The report that was published yesterday
+- Companies that fail to innovate
+
+**Which**: non-defining clause (with comma)
+- The report, which was published yesterday, shows...
+- The policy, which starts next month, aims to...
+
+### Who vs Whom
+
+**Who**: subject
+- Who wrote the report?
+- The economist who predicted the crisis
+
+**Whom**: object (formal, often replaced by 'who' in modern usage)
+- To whom it may concern (formal)
+- The person whom you mentioned
+- Better: The person you mentioned
+
+## Redundant Expressions
+
+### Delete These Entirely
+
+- added bonus → bonus
+- advance warning → warning
+- basic fundamentals → fundamentals
+- close proximity → proximity
+- completely eliminate → eliminate
+- consensus of opinion → consensus
+- end result → result
+- exact same → same
+- fall down → fall
+- final conclusion → conclusion
+- first priority → priority
+- forward planning → planning
+- free gift → gift
+- future potential → potential
+- general public → public
+- general consensus → consensus
+- lag behind → lag
+- mutual cooperation → cooperation
+- necessary prerequisite → prerequisite
+- past experience → experience
+- personal opinion → opinion
+- plan ahead → plan
+- postpone until later → postpone
+- raise up → raise
+- repeat again → repeat
+- revert back → revert
+- safe haven → haven
+- sink down → sink
+- spell out in detail → spell out
+- terrible tragedy → tragedy
+- true facts → facts
+- unexpected surprise → surprise
+- usual custom → custom
+
+## Clichés to Avoid
+
+These weaken writing through overuse:
+
+### Business Clichés
+- at the end of the day
+- think outside the box
+- move the needle
+- low-hanging fruit
+- paradigm shift
+- game changer
+- best practice
+- win-win situation
+- going forward
+- touch base
+- circle back
+- deep dive
+- drill down
+- bandwidth (meaning capacity)
+- on my radar
+- take it offline
+
+### Writing Clichés
+- needless to say (then don't say it)
+- it goes without saying (then don't say it)
+- last but not least
+- the fact of the matter is
+- at this point in time → now
+- in this day and age → today
+- push the envelope
+- cutting edge
+- state of the art
+- best of breed
+
+## Misused Phrases
+
+### Begs the Question
+
+**Wrong usage**: raises the question
+- ❌ This begs the question: what happens next?
+
+**Correct usage**: assumes the conclusion (logical fallacy)
+- The argument begs the question by assuming what it tries to prove
+
+**Better alternative**: Use "raises the question" instead
+
+### Decimate
+
+**Common misuse**: destroy completely
+**Correct meaning**: reduce by one-tenth
+
+Better alternatives: destroy, devastate, ravage
+
+### Literally
+
+**Misuse**: as intensifier
+- ❌ I literally died laughing
+
+**Correct usage**: actually, in reality
+- ✓ The temperature literally hit 40°C
+
+### Unique
+
+Cannot be qualified - something is either unique or not
+
+**Wrong**:
+- ❌ very unique
+- ❌ quite unique
+- ❌ rather unique
+- ❌ somewhat unique
+
+**Correct**:
+- ✓ unique
+- ✓ almost unique
+- ✓ nearly unique
+
+## Split Infinitives
+
+The Economist accepts split infinitives when they sound natural:
+
+**Acceptable**:
+- to boldly go
+- to really understand
+- to carefully consider
+
+**Awkward alternatives**:
+- ❌ boldly to go
+- ❌ really to understand
+
+**Guideline**: Avoid if the split is awkward or unnecessary
+
+## Preposition Placement
+
+Ending sentences with prepositions is acceptable and often clearer:
+
+**Natural**:
+- What are you talking about?
+- Which company do you work for?
+- This is something we should think about
+
+**Awkward**:
+- ❌ About what are you talking?
+- ❌ For which company do you work?
+- ❌ This is something about which we should think
+
+## Double Negatives
+
+Avoid double negatives:
+
+**Weak**:
+- not uncommon → common
+- not unlikely → likely
+- not dissimilar → similar
+- not unimportant → important
+
+## Anthropomorphism
+
+Avoid attributing human qualities to inanimate objects:
+
+**Weak**:
+- The data wants to tell us...
+- The market feels uncertain...
+- The economy is crying out for...
+
+**Better**:
+- The data suggest...
+- Market indicators show uncertainty...
+- The economy needs...
+
+## Mixed Metaphors
+
+Avoid combining incompatible metaphors:
+
+**Wrong**:
+- ❌ We'll burn that bridge when we come to it
+- ❌ It's not rocket surgery
+- ❌ The ball is in your court, so the sky's the limit
+
+## Subject-Verb Agreement
+
+Watch for errors with collective nouns and compound subjects:
+
+**Correct**:
+- The number of companies is rising (singular)
+- A number of companies are closing (plural)
+- Neither the CEO nor the directors were available (plural - match nearest)
+- Either rates or inflation has to fall (singular - match nearest)
+
+## Dangling Modifiers
+
+Ensure modifiers clearly refer to the correct subject:
+
+**Wrong**:
+- ❌ Walking down the street, the building looked impressive
+- (The building wasn't walking)
+
+**Correct**:
+- ✓ Walking down the street, I saw an impressive building
+- ✓ The building looked impressive as I walked down the street
+
+## Parallel Structure
+
+Maintain consistency in lists and comparisons:
+
+**Wrong**:
+- ❌ The plan aims to reduce costs, improving efficiency, and innovation
+- ❌ She enjoys reading, writing, and to travel
+
+**Correct**:
+- ✓ The plan aims to reduce costs, improve efficiency and boost innovation
+- ✓ She enjoys reading, writing and travelling
+
+## Gender-Neutral Language
+
+### Avoid Generic Masculine
+
+**Outdated**:
+- ❌ The businessman should review his accounts
+- ❌ Every worker must submit his timesheet
+- ❌ Man has conquered space
+
+**Better options**:
+- Pluralise: "Businesspeople should review their accounts"
+- Use "they": "Every worker must submit their timesheet"
+- Reword: "Humanity has conquered space" or "Humans have reached space"
+
+### Job Titles
+
+| Outdated | Preferred |
+|----------|-----------|
+| Businessman | Business executive, business owner |
+| Fireman | Firefighter |
+| Policeman | Police officer |
+| Stewardess | Flight attendant |
+| Manpower | Workforce, staff |
+
+**Note**: The Economist retains "chairman" (it dislikes "chair"/"chairperson" for people) and permits "mankind" — follow the document's existing usage.
+
+### Titles and Honorifics
+
+- Use "Ms" unless a woman has expressed a preference for "Mrs" or "Miss"
+- Avoid unnecessary identification of gender: "the doctor" not "the lady doctor"
+- Use professional titles equally: If using "Dr Smith" for a man, use "Dr Jones" for a woman
+
+### Singular They
+
+The singular "they" is acceptable for:
+- Unknown or unspecified individuals: "Each applicant should submit their CV"
+- Non-binary individuals who use they/them pronouns
+
+## Sensitivity and Inclusive Language
+
+**Note**: This section reflects general modern-media practice, not Economist doctrine. The Economist prizes plain, direct language and resists euphemism; where a substitution below would blur meaning, prefer precision (see General Principles). Match the document's established conventions.
+
+### People-First Language
+
+Put the person before the condition:
+
+| Less inclusive | More inclusive |
+|----------------|----------------|
+| The disabled | People with disabilities |
+| Diabetics | People with diabetes |
+| The homeless | People experiencing homelessness |
+| The elderly | Older people, older adults |
+| The mentally ill | People with mental health conditions |
+
+**Exception**: Some communities prefer identity-first language (e.g., "autistic person" preferred by many autistic people). When possible, follow the preference of the group being discussed.
+
+### Race and Ethnicity
+
+- Capitalisation varies by style: AP capitalises "Black" (not "white"); The Economist lower-cases both "black" and "white". Match the document's existing convention
+- Avoid using "minorities" to mean all non-white people
+- Be specific when possible: "Chinese", "Nigerian", "Mexican" rather than generic "Asian", "African", "Hispanic"
+- Avoid stereotypes and generalisations
+- Do not mention race unless relevant to the story
+
+### Disability
+
+- Avoid euphemisms: "differently abled", "special needs", "handicapable"
+- Use neutral terms: "uses a wheelchair" not "wheelchair-bound" or "confined to a wheelchair"
+- Avoid portraying people with disabilities as inspirational merely for existing
+- Do not describe medical conditions in dramatic terms: "suffering from" → "has" or "lives with"
+
+### Mental Health
+
+| Avoid | Use |
+|-------|-----|
+| Crazy, insane, nuts | [Be specific about behaviour] |
+| Committed suicide | Died by suicide (common media guidance; The Economist permits "committed suicide") |
+| Schizophrenic (as adjective) | "A person with schizophrenia" |
+| Mentally ill (noun) | People with mental illness |
+
+### Age
+
+- Avoid ageist language: "spry for her age", "still sharp at 80"
+- Use "older people" or "older adults" rather than "the elderly" or "the aged"
+- Avoid assumptions about capability based on age
+- Be precise about age when relevant rather than vague generational labels
+
+### Sexuality and Gender Identity
+
+- Use the terminology individuals prefer for themselves
+- LGBTQ+ is a common umbrella term (note: preferences vary by region and community)
+- Use appropriate pronouns (he, she, they) as indicated
+- "Sexual orientation" not "sexual preference"
+- "Transgender" is an adjective: "a transgender person" not "a transgender" or "transgendered"
+
+### Economic Status
+
+- "Third-world" is dated: prefer "developing countries" or "low-income countries"
+- The Economist writes plainly of "the poor" and "slums" — do not euphemise (precision over euphemism)
+
+### General Principles
+
+1. **Precision over euphemism**: Be clear and accurate, not vague
+2. **Respect preferences**: Where known, use terms people use for themselves
+3. **Avoid defining people by single characteristics**: "a woman with epilepsy" not "an epileptic woman"
+4. **Update your language**: Preferred terms evolve; stay current
+5. **Focus on relevance**: Only mention characteristics when relevant to the story

--- a/plugins/economist-style/skills/economist-style/reference/DIALECT-CONVENTIONS.md
+++ b/plugins/economist-style/skills/economist-style/reference/DIALECT-CONVENTIONS.md
@@ -1,0 +1,341 @@
+# Dialect Conventions Guide
+
+**IMPORTANT**: This reference is for dialect consistency checking only. Always detect and match the document's existing dialect before applying any rules.
+
+## Detecting Document Dialect
+
+Before making suggestions, examine:
+- Spelling patterns (-ise vs -ize, colour vs color)
+- Date formats (1st January vs January 1st)
+- Quotation marks (single vs double)
+- Vocabulary choices (autumn vs fall, programme vs program)
+
+**Rule**: Match the document's existing conventions. Only flag inconsistencies within the same document.
+
+---
+
+## British English Conventions
+
+Use these rules ONLY if the document is clearly using British English or the user explicitly requests British conventions.
+
+### Spelling
+
+### -ise vs -ize
+
+The Economist uses -ise endings (following British convention).
+
+**Correct**:
+- organise, organisation
+- realise, realisation
+- recognise, recognition
+- analyse, analysis
+- criticise, criticism
+- summarise, summary
+- prioritise, priority
+- specialise, specialist
+
+**Exceptions** (always -ize):
+- size
+- prize
+- capsize
+- seize
+
+### Common British vs American Spellings
+
+| British (use) | American (avoid) |
+|--------------|------------------|
+| colour | color |
+| favour | favor |
+| labour | labor |
+| honour | honor |
+| behaviour | behavior |
+| neighbour | neighbor |
+| programme | program (except computer program) |
+| centre | center |
+| theatre | theater |
+| metre | meter (unit) |
+| litre | liter |
+| defence | defense |
+| licence (noun) | license (both) |
+| license (verb) | license (both) |
+| practice (noun) | practice (both) |
+| practise (verb) | practice (both) |
+| travelling | traveling |
+| cancelled | canceled |
+| modelling | modeling |
+| judgement | judgment |
+| grey | gray |
+| cheque | check (payment) |
+| aeroplane | airplane |
+
+Note: "focused" and "judgment" are The Economist's own preferences, though "judgement" is common British usage.
+
+## Punctuation
+
+### Quotation Marks
+
+Standard British publishing uses **single quotes** for quotations:
+- 'The prime minister said rates would fall'
+- She described it as 'disappointing'
+
+**Double quotes** only for quotes within quotes:
+- He said: 'The minister called it "unprecedented"'
+
+**Note**: The Economist itself uses double quotes with British (logical) punctuation placement — see PUNCTUATION.md. Match whichever convention the document already uses.
+
+### Punctuation with Quotes
+
+Place punctuation **outside** quotes unless it's part of the quotation:
+- The report was described as 'misleading'. (period outside)
+- Did he say it was 'impossible'? (question mark outside)
+- He asked, 'What time is it?' (question mark inside - part of quote)
+
+### Serial (Oxford) Comma
+
+British practice — and The Economist — **omit** the comma before 'and' in lists:
+- The firm operates in London, Paris and Berlin
+- We need engineers, designers and project managers
+
+Use it only when needed to prevent ambiguity (see PUNCTUATION.md).
+
+### Em-dashes
+
+Use em-dashes for parenthetical statements:
+- The policy—launched in March—failed to gain support
+- Brexit has created problems—some predicted, others not
+
+No spaces around em-dashes.
+
+### Hyphens
+
+**Compound modifiers before nouns**:
+- a well-known economist
+- a 20-year bond
+- a high-quality product
+
+**Not after nouns**:
+- The economist is well known
+- The bond matures in 20 years
+
+**Ages and numbers**:
+- a five-year-old child
+- a 30-year-old policy
+- a two-thirds majority
+
+## Dates and Numbers
+
+### Date Format
+
+**The Economist's format**: month, ordinal day, year
+- January 1st 2025
+- on March 15th
+- since April 5th
+
+**Other British usage** (acceptable if the document already uses it):
+- 1 January 2025
+
+**Not American format**:
+- ❌ January 1, 2025
+- ❌ March 15, 2024
+
+### Ordinal Indicators
+
+Use 'st', 'nd', 'rd', 'th' for dates:
+- 1st, 2nd, 3rd, 4th, 21st, 22nd, 23rd
+
+### Numbers
+
+**Spell out one to ten**:
+- five people
+- three companies
+- ten million
+
+**Use numerals from 11**:
+- 15 people
+- 127 companies
+- £4.2m
+
+**Exceptions** (always use numerals):
+- Percentages: 5%, 2.5%
+- Money: £5, $3m
+- Ages 11 and above: aged 45 (spell out one to ten: "a five-year-old")
+- Measurements: 5kg, 3km
+- Dates: May 5th
+- Times: 5pm, 3:30am
+
+### Large Numbers
+
+British conventions:
+- Use 'm' for million: £5.2m, 14m people
+- Use 'bn' for billion: £2.3bn, 7.5bn
+- Use commas: 1,250 (not 1250)
+- Use decimals: 4.7%, £2.5m (not 4,7% or £2,5m)
+
+## Time and Dates
+
+### Time Format
+
+Use 12-hour clock with am/pm:
+- 3pm, 9:30am, 11:45pm
+- Not: 15:00, 09:30, 23:45
+
+No spaces, no full stops:
+- 3pm (not 3 p.m. or 3 PM)
+
+### Seasons
+
+Lowercase unless part of a proper noun:
+- spring, summer, autumn, winter
+- But: Spring Budget, Autumn Statement
+
+## Capitalisation
+
+### Titles
+
+Capitalise formal titles before names:
+- President Joe Biden
+- But: Joe Biden, the president
+
+### Government and Institutions
+
+- the government (lowercase)
+- parliament (lowercase)
+- the House of Commons
+- the Treasury
+- the Bank of England
+- but: central bank (when not specific)
+
+### Headlines
+
+Use sentence case, not title case:
+- Britain's economy slows as rates bite
+- Not: Britain's Economy Slows As Rates Bite
+
+## Vocabulary Preferences
+
+### British Terms
+
+| British (use) | American (avoid) |
+|--------------|------------------|
+| autumn | fall |
+| lift | elevator |
+| underground/tube | subway |
+| postcode | zip code |
+| mobile phone | cell phone |
+| holiday | vacation |
+| estate agent | realtor |
+| CV | résumé |
+| shares | stocks |
+| maths | math |
+| sport | sports |
+| pavement | sidewalk |
+| lorry | truck |
+| petrol | gas/gasoline |
+
+### Collective Nouns
+
+The Economist treats companies, governments and parties as **singular**:
+- The government is divided
+- The company is expanding
+
+British English often uses the plural when stressing the members, and sports teams usually take it:
+- Manchester United are playing
+- The team are performing well
+
+American English uses the singular throughout.
+
+## Miscellaneous
+
+### Shall vs Will
+
+The Economist generally uses 'will' rather than 'shall':
+- The bank will cut rates (not shall)
+- Exception: legal/formal contexts where 'shall' is conventional
+
+### Gotten
+
+Avoid 'gotten' (Americanism):
+- have got (not have gotten)
+- have obtained
+- have become
+
+### Different from/to/than
+
+British preference:
+- different from (preferred)
+- different to (acceptable)
+- different than (avoid - Americanism)
+
+---
+
+## American English Conventions
+
+Use these rules ONLY if the document is clearly using American English.
+
+### Spelling
+
+#### -ize vs -ise
+
+American English uses -ize endings:
+- organize, organization
+- realize, realization
+- recognize, recognition
+- analyze, analysis
+- criticize, criticism
+
+#### Common American Spellings
+
+| American (use) | British |
+|----------------|---------|
+| color | colour |
+| favor | favour |
+| labor | labour |
+| honor | honour |
+| behavior | behaviour |
+| center | centre |
+| theater | theatre |
+| meter | metre |
+| liter | litre |
+| defense | defence |
+| license (both) | licence (noun), license (verb) |
+| practice (both) | practice (noun), practise (verb) |
+| traveling | travelling |
+| canceled | cancelled |
+| modeling | modelling |
+| judgment | judgement |
+| gray | grey |
+| check | cheque (payment) |
+| airplane | aeroplane |
+
+### Punctuation
+
+**Use double quotes** for quotations:
+- The prime minister said rates would "fall sharply"
+
+**Use single quotes** for quotes within quotes:
+- He said: "The minister called it 'unprecedented'"
+
+### Dates
+
+**American format**: month, day, year
+- January 1, 2025
+- March 15, 2024
+
+### Vocabulary
+
+| American | British |
+|----------|---------|
+| fall | autumn |
+| elevator | lift |
+| subway | underground/tube |
+| zip code | postcode |
+| cell phone | mobile phone |
+| vacation | holiday |
+| résumé | CV |
+| math | maths |
+
+### Collective Nouns
+
+American English treats collective nouns as singular:
+- The government is divided
+- The team is performing well

--- a/plugins/economist-style/skills/economist-style/reference/ECONOMIST-SIGNATURE.md
+++ b/plugins/economist-style/skills/economist-style/reference/ECONOMIST-SIGNATURE.md
@@ -1,0 +1,39 @@
+# Economist Signature Rules
+
+The compact rules that make copy recognizably Economist. Apply these first; load the detailed reference files only when a deeper check is needed. In dialect-neutral mode, rules marked (B) apply only to British-dialect documents — the rest apply everywhere.
+
+## Numbers
+- Spell out one to ten; figures from 11
+- Money: $5m, $3.2bn, $1trn (symbol before, no space, abbreviated)
+- Percentages: % with figures ("5%"); "percentage points" for changes in rates
+- Never start a sentence with a figure — spell it out or rewrite
+
+## Dates and times
+- Month first with ordinal: "April 5th", "January 1st 2025"
+- Decades without apostrophe: "the 1990s"
+- Times: "3pm", "9.30am"; prefer "noon" and "midnight"
+
+## Punctuation
+- No serial (Oxford) comma unless needed for clarity: "tax, spending and regulation"
+- Double quotation marks, single inside; punctuation outside quotes unless part of the original
+- No full stops in abbreviations: Mr, Dr, GDP, eg, ie (a comma follows "ie")
+- Initials in names take points: J.K. Rowling
+- Hyphenate co-operate, co-ordinate, pre-war, post-war
+- No exclamation marks; rhetorical questions rarely
+
+## People
+- Full name on first mention; honorific + surname thereafter: "Janet Yellen... Ms Yellen"
+- Job titles lower case: "Jerome Powell, chairman of the Federal Reserve" — never "Chairman Powell"
+- "Chairman" is retained; the Economist dislikes "chair" and "chairperson" for people
+
+## Grammar
+- Companies, governments and parties are singular: "the government is"
+- "Will", not "shall"
+- Short words, active voice, one idea per sentence
+
+## Headings
+- Sentence case only: "The rise and fall of economic theory"
+
+## Spelling (B)
+- -ise endings: organise, realise
+- "judgment", "focused"

--- a/plugins/economist-style/skills/economist-style/reference/NUMBERS.md
+++ b/plugins/economist-style/skills/economist-style/reference/NUMBERS.md
@@ -1,0 +1,194 @@
+# Numbers and Figures Guidelines
+
+Numbers convey precision. Handle them consistently to maintain credibility and readability.
+
+## When to Spell Out vs Use Numerals
+
+### Spell Out
+- Numbers one to ten: "three companies", "ten years"
+- Numbers at the start of sentences: "Twenty people attended" (or rewrite to avoid)
+- Round numbers used loosely: "about a hundred", "thousands of people"
+- Common expressions: "the big three automakers", "the four horsemen"
+
+### Use Numerals
+- Numbers 11 and above: "12 countries", "250 employees"
+- Numbers with units: "5km", "3%", "$7m"
+- Ages: "aged 45" (ages one to ten follow the spell-out rule: "a six-year-old child")
+- Scores and votes: "won 3-2", "passed 52-48"
+- Addresses: "10 Downing Street"
+- Dates and times (see below)
+
+### Mixed Usage in Same Sentence
+When a sentence contains both small and large numbers of the same type, use numerals for all:
+- "The sample included 8 small firms and 12 large ones"
+- NOT: "eight small firms and 12 large ones"
+
+## Percentages
+
+### Format
+- Use the % symbol with numerals: "5%", "10.5%"
+- Spell out "per cent" in running text if desired: "five per cent"
+- No space before %: "10%" not "10 %"
+
+### Percentage Points vs Percentages
+Be precise about the difference:
+
+| Scenario | Correct | Incorrect |
+|----------|---------|-----------|
+| Rate moves from 5% to 7% | "Rose by 2 percentage points" | "Rose by 2%" |
+| Quantity increases by 40% | "Rose by 40%" | "Rose by 40 percentage points" |
+
+**Wrong**: "Unemployment fell from 10% to 8%, a drop of 2%"
+**Correct**: "Unemployment fell from 10% to 8%, a drop of 2 percentage points"
+
+### Basis Points
+In financial contexts, 100 basis points = 1 percentage point:
+- "Interest rates rose by 25 basis points (0.25 percentage points)"
+
+## Fractions and Decimals
+
+### Fractions
+- Hyphenate spelled-out fractions: "two-thirds", "three-quarters"
+- Use numerals for precision: "3/4" or "0.75"
+- Mixed numbers: "2½" or "2.5"
+
+### Decimals
+- Use a full stop (period) as the decimal point: "3.5"
+- Limit decimal places to what is meaningful: "3.7%" not "3.7142857%"
+- Use leading zero: "0.5" not ".5"
+
+## Dates and Times
+
+### Dates
+
+**The Economist's format** — month first, with ordinal:
+- "January 1st 2024", "on April 5th", "since April 5th"
+
+**Other British usage** (acceptable if the document already uses it):
+- "1 January 2024"
+
+**American format**:
+- "January 1, 2024"
+
+### Decades and Centuries
+- "The 1990s" (no apostrophe)
+- "The mid-1980s"
+- "The 21st century" (not "21st Century")
+- "The early 2000s"
+
+### Times
+- Use the 12-hour clock in text: "3pm", "9.30am"
+- No space before am/pm
+- Use 24-hour clock only in technical contexts: "15:00"
+- "Noon" and "midnight" rather than "12pm" and "12am"
+
+### Spans
+- "2020-24" or "2020–24" (en dash)
+- "From 2020 to 2024" (not "from 2020-24")
+- "Between 2020 and 2024" (not "between 2020-24")
+
+## Currency
+
+### Format
+- Symbol before numeral: "$50", "£30", "€100"
+- No space between symbol and number
+
+### Large Amounts
+Use abbreviations for readability:
+
+| Amount | Write | Not |
+|--------|-------|-----|
+| $5,000,000 | $5m | $5 million |
+| $5,000,000,000 | $5bn | $5 billion |
+| $5,000,000,000,000 | $5trn | $5 trillion |
+
+### Specify Currency
+On first mention, clarify which dollar, pound, etc.:
+- "A$50bn" (Australian dollars)
+- "C$30m" (Canadian dollars)
+- "HK$100m" (Hong Kong dollars)
+
+### Exchange Rates
+- "The euro traded at $1.10"
+- "¥150 to the dollar"
+
+## Large Numbers
+
+### Thousands
+- Use commas: "10,000" not "10000"
+- Or write: "10,000" as "10,000"
+
+### Millions and Billions
+- Use abbreviations: "5m", "3.2bn", "1trn"
+- In tables, define abbreviations in headers or footnotes
+
+### Billions: American vs British
+The Economist uses the American billion (1,000,000,000 = 10⁹), not the British billion (10¹²):
+- 1 billion = 1,000 million
+- 1 trillion = 1,000 billion
+
+## Ordinals
+
+### When to Use
+- Dates: "January 1st", "the 21st century"
+- Rankings: "the 3rd largest economy"
+- Sequences: "for the 5th consecutive year"
+
+### Format
+- Use standard form: 1st, 2nd, 3rd, 4th (no superscript)
+- Spell out for first through tenth in running text: "the third quarter"
+
+## Ranges and Approximations
+
+### Ranges
+- Use en dash: "10–15%", "pages 5–10"
+- Or spell out: "10 to 15%", "from 5 to 10"
+- Never mix: NOT "from 10–15%"
+
+### Approximations
+- "About 100" or "roughly 100"
+- "Some 50 companies" (implies approximately)
+- Avoid false precision: "about 47%" should be "about 50%" or "nearly half"
+
+## Units of Measurement
+
+### Abbreviations
+No full stops in unit abbreviations:
+- km, kg, lb, oz, mph, kWh
+
+### Metric vs Imperial
+Consider your audience:
+- International: Use metric (km, kg, °C)
+- American contexts: May include imperial (miles, pounds, °F)
+- Provide conversions when helpful: "100km (62 miles)"
+
+### Spacing
+- No space between number and unit: "5km", "10kg"
+- Exception: "5 per cent" if spelling out
+
+## Tables and Charts
+
+### Consistency
+- Use the same format throughout a table
+- Align decimal points
+- Use consistent decimal places within columns
+
+### Headers
+- Include units in column headers: "Revenue ($m)"
+- Define abbreviations: "GDP, % change year on year"
+
+### Precision
+- Match precision to data quality
+- Avoid implying false precision: "3.7142857%" suggests more accuracy than likely exists
+
+## Common Errors
+
+| Error | Correction |
+|-------|------------|
+| "5,000,000 dollars" | "$5m" |
+| "50 %" | "50%" |
+| "between 10-20" | "between 10 and 20" or "10-20" |
+| ".5" | "0.5" |
+| "the 1990's" | "the 1990s" |
+| "12.00pm" | "noon" |
+| "a increase of 2%" (when rate moved from 5% to 7%) | "an increase of 2 percentage points" |

--- a/plugins/economist-style/skills/economist-style/reference/PRECISION.md
+++ b/plugins/economist-style/skills/economist-style/reference/PRECISION.md
@@ -1,0 +1,179 @@
+# Precision Guidelines
+
+## Weasel Words
+
+Weasel words are vague terms that lack specificity. They appear to make claims without committing to verifiable statements.
+
+### Common Weasel Words
+
+**Vague Quantifiers**:
+- many → how many? (give a number or percentage)
+- few → how many exactly?
+- several → specify the number
+- numerous → quantify
+- various → which ones specifically?
+- some → how many?
+
+**Vague Qualifiers**:
+- significant → how significant? (percentage, magnitude)
+- substantial → quantify the amount
+- considerable → specify
+- notable → in what way?
+- remarkable → what makes it remarkable?
+
+**Weasel Claims**:
+- "Studies show..." → Which studies? Cite them
+- "Experts say..." → Which experts? Name them
+- "It is widely believed..." → By whom? Evidence?
+- "Research indicates..." → What research? Reference it
+- "Many people think..." → What proportion? Evidence?
+
+### Examples with Fixes
+
+**Weak**: "Many companies are adopting remote work"
+**Strong**: "43% of FTSE 100 companies now offer remote work options" (2024 survey)
+
+**Weak**: "The project saw significant delays"
+**Strong**: "The project finished four months late"
+
+**Weak**: "Sales increased considerably"
+**Strong**: "Sales rose 23% year-on-year to £4.2m"
+
+## Filler Words and Phrases
+
+These add no meaning and should be deleted.
+
+### Common Fillers
+
+**Redundant Introductions**:
+- It should be noted that → Delete
+- It is important to realise that → Delete
+- The fact of the matter is → Delete
+- At this point in time → now
+- In this day and age → today, now
+- For all intents and purposes → Delete
+
+**Redundant Intensifiers**:
+- very unique → unique (unique cannot be qualified)
+- completely finish → finish
+- absolutely essential → essential
+- totally destroy → destroy
+- extremely critical → critical
+
+**Empty Phrases**:
+- in terms of → Delete or use "in"
+- in the process of → Delete
+- for the purpose of → to, for
+- in the final analysis → Delete
+- at the end of the day → ultimately, finally
+
+**Tautologies** (saying the same thing twice):
+- advance planning → planning
+- past history → history
+- future plans → plans
+- end result → result
+- final outcome → outcome
+- collaborate together → collaborate
+- join together → join
+
+## Hedging vs Precision
+
+### Excessive Hedging
+
+**Weak**: "This could possibly lead to somewhat better outcomes in certain cases"
+**Strong**: "This improves outcomes in 60% of cases"
+
+**Weak**: "The policy may potentially have a relatively positive impact"
+**Strong**: "The policy is expected to reduce costs by 15%"
+
+### When to Be Specific
+
+Replace vague time references:
+- "recently" → last month, in Q3, on October 15th
+- "soon" → next week, by March, within 30 days
+- "in the near future" → by year-end, within six months
+
+Replace vague locations:
+- "in many countries" → in the UK, US and Germany
+- "across the region" → in Southeast Asia (or name specific countries)
+
+Replace vague sources:
+- "according to reports" → according to the IMF's October report
+- "data shows" → ONS data shows
+
+## Numbers and Statistics
+
+### Be Specific
+
+**Vague**: "The unemployment rate is low"
+**Precise**: "Unemployment stands at 4.2%, its lowest since 2019"
+
+**Vague**: "Inflation has risen sharply"
+**Precise**: "Inflation jumped from 2.1% to 4.7% in six months"
+
+### Context Matters
+
+- Always provide context for numbers (up from what? compared to what?)
+- Use absolute numbers AND percentages when appropriate
+- Round appropriately (don't say 23.47% when 23% is clearer)
+
+### Date Precision
+
+- Use specific dates: "January 1st 2025" not "early 2025"
+- Be clear about timeframes: "between March and June 2024" not "in spring"
+- Use "last month" only in time-sensitive contexts; otherwise specify
+
+## Attribution
+
+Always attribute claims and viewpoints.
+
+**Weak**: "It is believed interest rates will fall"
+**Strong**: "The Bank of England expects to cut rates twice this year"
+
+**Weak**: "Critics argue the policy will fail"
+**Strong**: "Opposition MPs claim the policy will cost £2bn more than projected"
+
+## Removing Redundancy
+
+### Redundant Pairs
+
+Delete one:
+- each and every → each OR every
+- first and foremost → first
+- null and void → void
+- various and sundry → various
+- hopes and dreams → hopes
+- aid and abet → aid
+
+### Unnecessary Modifiers
+
+- completely unanimous → unanimous
+- circle around → circle
+- close proximity → proximity
+- general consensus → consensus
+- unexpected surprise → surprise
+- free gift → gift
+
+## Clichés and Dead Metaphors
+
+Orwell's first rule: if you are used to seeing a figure of speech in print, don't use it. A cliché signals that the writer has stopped thinking; replace it with the plain meaning or a fresh image.
+
+Common offenders:
+
+- at the end of the day → ultimately, or cut
+- game-changer → say what changes
+- level playing field → fair competition
+- low-hanging fruit → the easiest gains
+- move the needle → make a difference (say how much)
+- paradigm shift → a change (say what kind)
+- perfect storm → say which factors coincided
+- silver bullet / holy grail → a simple solution / the ultimate goal
+- sea change / watershed moment → a big change (say what changed)
+- think outside the box → cut; describe the unconventional idea itself
+- tip of the iceberg → say what remains hidden, and how much
+- double-edged sword → say both effects
+- the fact of the matter is → cut
+- last but not least → finally
+- leave no stone unturned → search thoroughly
+
+The test: if the phrase would appear in any company's press release, it is not doing any work in yours.

--- a/plugins/economist-style/skills/economist-style/reference/PUNCTUATION.md
+++ b/plugins/economist-style/skills/economist-style/reference/PUNCTUATION.md
@@ -1,0 +1,263 @@
+# Punctuation Guidelines
+
+Punctuation exists to clarify meaning. Use it sparingly but precisely. Every mark should serve a purpose.
+
+## Commas
+
+### Serial (Oxford) Comma
+
+The Economist does **not** use the serial comma except when needed for clarity.
+
+**Standard usage**:
+- "France, Germany and Italy" (no comma before "and")
+- "The report covered tax, spending and regulation"
+
+**Use when needed for clarity**:
+- "The options were ham and eggs, toast, and cereal" (prevents confusion)
+- "I dedicate this to my parents, Ayn Rand and God" needs comma: "my parents, Ayn Rand, and God"
+
+### Restrictive vs Non-Restrictive Clauses
+
+**Restrictive** (no commas) - essential information:
+- "The countries that signed the treaty must comply"
+- "Workers who lack skills struggle to find jobs"
+
+**Non-restrictive** (commas) - additional information:
+- "China, which signed the treaty, must comply"
+- "The workers, who had been there for years, were laid off"
+
+### Common Comma Errors
+
+| Error | Correction |
+|-------|------------|
+| "The company, said it would expand" | "The company said it would expand" |
+| "He argued that, the policy failed" | "He argued that the policy failed" |
+| "However the results were clear" | "However, the results were clear" |
+
+### Comma Splices
+
+Never join two independent clauses with just a comma.
+
+**Wrong**: "The economy grew, inflation remained low"
+
+**Correct options**:
+- "The economy grew; inflation remained low"
+- "The economy grew, and inflation remained low"
+- "The economy grew. Inflation remained low"
+
+## Semicolons
+
+Use semicolons to:
+
+### Link Related Independent Clauses
+- "The economy is growing; unemployment is falling"
+- "Interest rates rose; the market corrected"
+
+### Separate Complex List Items
+When list items contain commas, use semicolons between them:
+- "The delegation included Smith, the chairman; Jones, the treasurer; and Brown, the secretary"
+
+### Before Conjunctive Adverbs
+- "Growth slowed; however, employment held steady"
+- "The policy failed; therefore, it was abandoned"
+
+**Common conjunctive adverbs**: however, therefore, moreover, nevertheless, consequently, furthermore, otherwise
+
+## Colons
+
+### Introduce Lists or Explanations
+- "Three factors drove growth: exports, investment and consumption"
+- "The conclusion was clear: reform had failed"
+
+### After Complete Sentences Only
+The text before a colon must be a complete sentence.
+
+**Wrong**: "The factors were: exports and investment"
+
+**Correct**: "The factors were exports and investment" or "Two factors drove growth: exports and investment"
+
+### Capitalisation After Colons
+Do not capitalise after a colon unless what follows is a complete sentence or a proper noun.
+- "The message was clear: austerity would continue"
+- "One truth emerged: Markets do not wait"
+
+## Apostrophes
+
+### Possessives
+
+**Singular nouns**: Add 's
+- "The company's profits"
+- "James's book" (not "James' book")
+
+**Plural nouns ending in s**: Add apostrophe only
+- "The companies' profits"
+- "The workers' demands"
+
+**Irregular plurals**: Add 's
+- "The children's school"
+- "The people's choice"
+
+### Special Cases
+
+| Case | Example |
+|------|---------|
+| Joint possession | "Smith and Jones's firm" (one firm) |
+| Separate possession | "Smith's and Jones's firms" (two firms) |
+| Compound nouns | "The attorney-general's opinion" |
+| Time expressions | "A week's notice", "Two years' experience" |
+
+### Contractions
+Apostrophes replace omitted letters:
+- "It's" = "It is" or "It has"
+- "Don't" = "Do not"
+- "The '90s" = "The 1990s"
+
+**Warning**: "Its" (possessive) has no apostrophe. "It's" always means "it is" or "it has".
+
+## Quotation Marks
+
+### The Economist Style
+
+The Economist uses a hybrid approach:
+- **Double quotes** for primary quotations: "This is a quote"
+- **Single quotes** for quotes within quotes: "When I say 'immediately', I mean before April"
+- **Logical punctuation**: Punctuation goes outside quotes unless part of the original quotation
+
+This combines double quotes (American convention) with logical punctuation (British convention).
+
+### Standard British vs American Style
+
+**Standard British**:
+- Single quotes for quotations: 'This is a quote'
+- Double quotes for quotes within quotes: 'He said "yes" to that'
+- Punctuation outside quotes unless part of the quotation
+
+**Standard American**:
+- Double quotes for quotations: "This is a quote"
+- Single quotes for quotes within quotes: "He said 'yes' to that"
+- Punctuation inside quotes
+
+### Punctuation Placement
+
+**Inside quotes** (when part of the original):
+- She asked, 'Where is it?'
+- He shouted, 'Stop!'
+
+**Outside quotes** (when not part of the original):
+- What did she mean by 'reform'?
+- The report mentioned 'significant progress'.
+
+### Scare Quotes
+Use sparingly to indicate irony or distance:
+- The 'experts' failed to predict the crisis
+- Their 'solution' made things worse
+
+Avoid overuse; it becomes tiresome.
+
+## Hyphens
+
+### Compound Modifiers Before Nouns
+Hyphenate compound adjectives before a noun:
+- "A well-known economist" but "The economist is well known"
+- "A long-term strategy" but "The strategy is long term"
+- "High-quality research" but "Research of high quality"
+
+### Prefixes
+The Economist retains hyphens in many prefixed words that American style closes up:
+
+| Economist style | American style |
+|-----------------|----------------|
+| Co-operate | Cooperate |
+| Co-ordinate | Coordinate |
+| Pre-war | Prewar |
+| Post-war | Postwar |
+
+In a document written in American English, match the closed forms already in use.
+
+**Always hyphenate** (for clarity):
+- "Re-cover" (cover again) vs "Recover" (get back)
+- "Re-sign" (sign again) vs "Resign" (quit)
+- Before capitals: "Anti-American", "Pro-European"
+- Double vowels when unclear: "Co-opt", "Re-elect"
+
+### Numbers
+- Twenty-one to ninety-nine
+- Two-thirds, three-quarters
+- A five-year plan, a ten-point lead
+
+### Common Hyphenated Terms
+
+| Hyphenated | Not Hyphenated |
+|------------|----------------|
+| Self-made | Selfless |
+| Cross-border | Crossfire |
+| Half-hearted | Halfway |
+| Full-time (adj) | Full time (noun) |
+| Part-time (adj) | Part time (noun) |
+
+## Dashes
+
+### En Dash (–)
+Use for ranges and connections:
+- "Pages 10–15"
+- "The London–Paris train"
+- "The 2020–21 fiscal year"
+- "The Conservative–Liberal coalition"
+
+### Em Dash (—)
+Use sparingly for emphasis or interruption:
+- "The result—surprising to many—was a landslide"
+- "Three factors mattered: growth, inflation and—most critically—employment"
+
+**Prefer parentheses or commas** in most cases. Em dashes should be rare.
+
+**No spaces** around em dashes.
+
+## Parentheses and Brackets
+
+### Parentheses ()
+For supplementary information:
+- "The GDP (gross domestic product) grew by 3%"
+- "Output rose (see chart)"
+
+Keep parenthetical content brief. If it's essential, integrate it into the sentence.
+
+### Square Brackets []
+For insertions in quotations:
+- "He said the policy [on immigration] was flawed"
+- "The report noted that '[t]he results were clear'"
+
+## Ellipses
+
+Use three dots (...) to indicate omission:
+- "The report stated that growth... would continue"
+
+**Avoid** ellipses for trailing off or creating suspense. This is not creative writing.
+
+## Full Stops (Periods)
+
+### Abbreviations
+No full stops in abbreviations:
+- GDP, IMF, UN, EU, NATO
+- Mr, Mrs, Dr, St
+- kg, km, mph
+
+### Sentences
+One space after a full stop, not two.
+
+## Question and Exclamation Marks
+
+### Questions
+Use only for genuine questions:
+- "Will interest rates rise?"
+
+**Avoid** rhetorical questions in serious analysis. They can seem glib.
+
+### Exclamation Marks
+Almost never use them. They suggest the writer is shouting.
+
+**Wrong**: "Growth surged to 5%!"
+
+**Correct**: "Growth surged to 5%"
+
+If the content is striking, the words should convey that—not the punctuation.

--- a/plugins/economist-style/skills/economist-style/reference/SPECIAL-CONTEXTS.md
+++ b/plugins/economist-style/skills/economist-style/reference/SPECIAL-CONTEXTS.md
@@ -1,0 +1,259 @@
+# Special Contexts Guidelines
+
+Certain contexts—quotations, foreign words, lists, and citations—require special handling to maintain clarity and consistency.
+
+## Foreign Words and Phrases
+
+### Italicisation
+Italicise foreign words and phrases that are not commonly used in English:
+- *Schadenfreude*, *coup d'état*, *Zeitgeist*
+- *De facto*, *pro bono*, *sine qua non*
+
+### When Not to Italicise
+Do not italicise foreign words that have become part of English:
+- Cliché, café, naive, resume (or résumé)
+- Per capita, ad hoc, status quo, vice versa
+- Détente, glasnost, perestroika
+
+**Test**: If it appears in an English dictionary without being marked as foreign, don't italicise.
+
+### Common Foreign Terms
+
+| Keep italicised | Now English (don't italicise) |
+|-----------------|-------------------------------|
+| *Realpolitik* | Ad hoc |
+| *Doppelgänger* | Per capita |
+| *Savoir-faire* | Entrepreneur |
+| *Weltanschauung* | Regime |
+| *In extremis* | Status quo |
+| *Fait accompli* | Vice versa |
+
+### Translation
+Provide translation or explanation when needed:
+- "The German concept of *Mittelstand* (medium-sized family businesses)"
+- "A sense of *Weltschmerz*, or world-weariness"
+
+### Accents
+Preserve accents on foreign words:
+- Café, résumé, naïve, façade
+- But not on fully anglicised words: elite, regime, role
+
+## Quotations
+
+### Direct Quotes
+Use quotation marks for direct speech or text (Economist style is double quotes; match the document):
+- He said, "The policy has failed"
+- The report stated that "growth will slow"
+
+### Quote Accuracy
+- Never alter quotes without indicating changes
+- Use [brackets] for insertions
+- Use ... for omissions
+- Correct obvious typos silently only if meaning is clear
+
+### Attribution
+
+**Position**: Attribution can come before, during, or after the quote:
+- Smith said, 'The economy is strong'
+- 'The economy is strong,' Smith said
+- 'The economy,' Smith said, 'is strong'
+
+**Verbs**: Use neutral verbs:
+- "Said" is almost always best
+- "Asked" for questions
+- "Wrote" for written sources
+
+**Avoid loaded verbs** (unless the connotation is intended):
+- Claimed, admitted, conceded, insisted
+
+### Long Quotations
+For quotes longer than a few sentences:
+- Consider using a block quote (indented, no quotation marks)
+- Or break up with attribution and paraphrase
+- Always ask: Is the full quote necessary?
+
+### Partial Quotes
+When quoting a phrase within your sentence:
+- "The minister called it a 'historic moment' for reform"
+- Ensure the quote integrates grammatically
+
+### Quotes Within Quotes
+Use single quotes within double (American) or double within single (standard British):
+- British: 'He said "yes" to that'
+- American: "He said 'yes' to that"
+- The Economist: double quotes primary with single inside, and logical punctuation placement (see PUNCTUATION.md)
+
+## Lists
+
+### When to Use Lists
+Lists work well for:
+- Multiple parallel items
+- Step-by-step instructions
+- Options or alternatives
+- Items that would be awkward in prose
+
+### Numbered vs Bulleted
+
+**Numbered lists** for:
+- Sequential steps (first, then, finally)
+- Ranked items (most to least important)
+- Items you'll reference by number
+
+**Bulleted lists** for:
+- Items of equal importance
+- Non-sequential items
+- Options without ranking
+
+### List Formatting
+
+**Punctuation**: Be consistent within a list.
+
+Option 1 (sentence fragments, no punctuation):
+- Lower case
+- No full stops
+- Short phrases
+
+Option 2 (complete sentences):
+- Start with capitals.
+- End with full stops.
+- Write complete sentences.
+
+**Parallel structure**: All items should have the same grammatical form.
+
+**Wrong**:
+- Reviewing the data
+- We analysed the results
+- To draw conclusions
+
+**Correct**:
+- Review the data
+- Analyse the results
+- Draw conclusions
+
+### Lead-ins
+The text introducing a list should end with a colon if the list completes the sentence:
+- "Three factors matter:" [list follows]
+
+No colon if the lead-in is a complete sentence:
+- "Consider these factors." [list follows]
+
+## Tables and Figures
+
+### Table Design
+- Clear, descriptive headers
+- Consistent formatting within columns
+- Units in headers, not in cells: "Revenue ($m)" not "$100m" in each cell
+- Align numbers on decimal points
+
+### Captions
+Tables and figures need captions that:
+- Describe what is shown
+- Include source information
+- Explain abbreviations or units
+
+**Example**:
+"Table 1: GDP growth by region, 2015–24 (% change year on year). Source: World Bank"
+
+### Referencing
+Refer to tables and figures by number:
+- "As shown in Table 1..."
+- "See Figure 3 for the trend"
+- Not "the table below" (position may change)
+
+### Data Presentation
+- Round to appropriate precision
+- Use consistent decimal places within a column
+- Include totals where helpful
+- Note any missing data
+
+## Citations and References
+
+### In-Text Citations
+For academic or research writing:
+- Author-date: (Smith, 2024) or Smith (2024)
+- Numbered: [1] or superscript¹
+
+### Attribution in Journalism
+For news writing, attribution is woven into text:
+- "According to a study by Harvard economists..."
+- "Research published in Nature suggests..."
+- "Data from the World Bank show..."
+
+### Source Credibility
+Be specific about sources:
+
+| Vague | Specific |
+|-------|----------|
+| "Studies show" | "A 2024 study by MIT found" |
+| "Experts say" | "Janet Yellen, former Fed chair, said" |
+| "Critics argue" | "The IMF warned that" |
+
+### Hyperlinks
+In digital text:
+- Link meaningful phrases, not "click here"
+- "A recent [World Bank report] found..."
+- Links should go to primary sources when possible
+
+## Footnotes and Endnotes
+
+### When to Use
+Footnotes work for:
+- Additional context that would interrupt flow
+- Source citations
+- Caveats or qualifications
+- Definitions
+
+### Keep Them Brief
+Long footnotes disrupt reading. If the information is important, put it in the main text.
+
+### Numbering
+- Number sequentially through the document
+- Use superscript numbers in text
+- Place the number after punctuation: "... in 2024."¹
+
+## Captions and Labels
+
+### Image Captions
+Should include:
+- What the image shows
+- When and where (if relevant)
+- Credit/source
+
+**Example**: "Protesters in Hong Kong, June 2019. Reuters"
+
+### Chart Labels
+- Clear axis titles
+- Units specified
+- Legend if multiple series
+- Source line
+
+## Dialogue and Interviews
+
+### Formatting Interviews
+**Q&A format**:
+- **Q**: What is your view?
+- **A**: I believe...
+
+**Narrative format**:
+- Weave quotes into prose
+- "Asked about growth, she replied that..."
+
+### Cleaning Up Speech
+Spoken language is messier than written. It's acceptable to:
+- Remove verbal fillers (um, uh, you know)
+- Fix minor grammatical errors
+- Condense for clarity
+
+But never:
+- Change the meaning
+- Improve the substance of what was said
+- Make quotes sound more impressive
+
+## Checklist
+
+- [ ] Are foreign words appropriately italicised (or not)?
+- [ ] Are quotations accurate and properly attributed?
+- [ ] Do lists have parallel structure?
+- [ ] Are tables clearly labelled with sources?
+- [ ] Is source attribution specific enough?
+- [ ] Are footnotes brief and necessary?

--- a/plugins/economist-style/skills/economist-style/reference/STRUCTURE.md
+++ b/plugins/economist-style/skills/economist-style/reference/STRUCTURE.md
@@ -1,0 +1,204 @@
+# Structure and Organisation Guidelines
+
+Good structure is invisible. Readers should follow your argument effortlessly. Every paragraph should earn its place.
+
+## Paragraph Structure
+
+### The Topic Sentence
+Each paragraph needs a clear topic sentence—usually the first. It tells readers what the paragraph is about.
+
+**Strong topic sentences**:
+- "Three factors explain the slowdown"
+- "The policy has failed for a simple reason"
+- "Critics make a valid point"
+
+**Weak topic sentences**:
+- "There are several things to consider" (vague)
+- "It is interesting to note that" (empty)
+- "Another thing is" (lacks substance)
+
+### One Idea Per Paragraph
+A paragraph should develop a single point. If you're making a new point, start a new paragraph.
+
+**Signs a paragraph should be split**:
+- It contains "however" or "on the other hand" mid-paragraph
+- It exceeds 150 words
+- It makes more than one main claim
+
+### Paragraph Length
+- Aim for 3–5 sentences
+- Vary length for rhythm, but avoid extremes
+- Single-sentence paragraphs can add emphasis—use sparingly
+- Very long paragraphs lose readers
+
+## Logical Flow and Transitions
+
+### Build Arguments Logically
+
+Order your paragraphs to lead readers through your argument:
+
+1. **Chronological**: Events in time order
+2. **Cause and effect**: Problem → causes → consequences
+3. **General to specific**: Broad claim → supporting details
+4. **Specific to general**: Evidence → broader conclusion
+5. **Compare and contrast**: Option A → Option B → Assessment
+6. **Order of importance**: Most significant point first (or last for emphasis)
+
+### Transition Words
+
+Use transitions to show relationships between ideas:
+
+| Relationship | Transitions |
+|--------------|-------------|
+| Addition | Also, moreover, furthermore, in addition |
+| Contrast | However, nevertheless, yet, by contrast, on the other hand |
+| Cause | Because, since, as a result, therefore, consequently |
+| Example | For instance, for example, such as |
+| Sequence | First, second, finally, then, next |
+| Conclusion | Thus, therefore, in short, ultimately |
+
+### Transition Warnings
+
+**Avoid overuse**: Too many transitions make prose feel mechanical.
+
+**Avoid weak transitions**:
+- "Another thing is..."
+- "Moving on to..."
+- "Speaking of which..."
+
+**Show, don't signpost**: Often the logic is clear without explicit transitions. Trust your reader.
+
+## Headlines and Titles
+
+### Headline Principles
+- Be specific, not generic
+- Include the key information
+- Use active voice when possible
+- Avoid questions (usually)
+- Keep under 10 words
+
+### Strong vs Weak Headlines
+
+| Weak | Strong |
+|------|--------|
+| "Economy news" | "Growth slows to 1% as exports fall" |
+| "A look at taxes" | "Tax reform stalls in Congress" |
+| "Interesting developments" | "China launches antitrust probe" |
+
+### Headline Style
+- Use sentence case (capitalise first word and proper nouns only), as The Economist does; match title case only if the document already uses it consistently
+- Omit full stops at the end
+- Avoid abbreviations readers may not know
+- No exclamation marks
+
+## The Lead (Opening)
+
+### Hook the Reader
+The first sentence must earn the second. Start with something concrete, surprising, or significant.
+
+**Strong leads**:
+- Start with a striking fact: "China now consumes more cement than the rest of the world combined"
+- Start with a person or scene: "When Maria Chen opened her factory in 2010..."
+- Start with a question (sparingly): "Can democracy survive the internet?"
+- Start with the news: "The Federal Reserve raised interest rates for the tenth consecutive time"
+
+**Weak leads**:
+- Definitions: "Inflation is defined as..."
+- History lessons: "Since ancient times, humans have..."
+- Empty statements: "There are many factors to consider..."
+- Clichés: "In today's fast-paced world..."
+
+### The Nut Paragraph
+After the lead, include a paragraph that summarises what the piece is about and why it matters. This is the "nut graf"—the nutshell summary.
+
+**Elements of a good nut paragraph**:
+- What is happening
+- Why it matters
+- What the piece will cover
+
+## Body Structure
+
+### The Inverted Pyramid
+In news writing, put the most important information first:
+1. Lead: The news
+2. Nut graf: Context and significance
+3. Details: Supporting information
+4. Background: Additional context
+5. Least essential: Can be cut if needed
+
+### For Analysis and Features
+Build an argument or narrative:
+1. Hook: Engaging opening
+2. Setup: Context and stakes
+3. Development: Evidence, examples, analysis
+4. Complications: Counterarguments, nuances
+5. Resolution: Conclusion and implications
+
+### Signposting Structure
+For longer pieces, help readers navigate:
+- Subheadings break up long text
+- Numbered points for lists
+- "First... Second... Third..." for sequential arguments
+- Brief summaries of what's coming
+
+## Conclusions
+
+### End with Purpose
+The conclusion should do more than stop. It should:
+- Summarise the main point (briefly)
+- Provide perspective or implications
+- Leave readers with something to think about
+- Look forward when appropriate
+
+### Strong Closings
+
+**Return to the opening**: Circle back to your lead for symmetry.
+**A telling detail**: End with a specific image or quote.
+**The bigger picture**: What does this mean for the future?
+**A call to action**: What should be done? (When appropriate)
+
+### Weak Closings
+
+**Avoid**:
+- "In conclusion..." (unnecessary signposting)
+- Introducing new information
+- Clichés: "Only time will tell"
+- Trailing off without purpose
+- Mere summary of everything already said
+
+## Common Structural Problems
+
+### Problem: Burying the Lead
+The main point appears in paragraph three or four.
+
+**Fix**: Move the key information up. Ask: "What's the most important thing?" Put that first.
+
+### Problem: Repetition
+The same point is made in multiple paragraphs.
+
+**Fix**: Combine or cut. Each paragraph should add something new.
+
+### Problem: Logical Gaps
+The argument jumps from A to C without B.
+
+**Fix**: Add the missing step, or acknowledge the leap explicitly.
+
+### Problem: Anticlimactic Ending
+The piece fizzles out with minor details.
+
+**Fix**: Save something strong for the end. Cut trailing details.
+
+### Problem: Too Many Subplots
+The piece tries to cover too much.
+
+**Fix**: Focus. What is this piece really about? Cut tangents or save them for another piece.
+
+## Checklist
+
+- [ ] Does every paragraph have a clear topic?
+- [ ] Is the most important information near the top?
+- [ ] Does the lead hook the reader?
+- [ ] Is the structure logical and easy to follow?
+- [ ] Do transitions connect ideas without being mechanical?
+- [ ] Does the conclusion add value, not just summarise?
+- [ ] Could any paragraph be cut without loss?

--- a/plugins/economist-style/skills/economist-style/reference/TONE.md
+++ b/plugins/economist-style/skills/economist-style/reference/TONE.md
@@ -1,0 +1,223 @@
+# Tone and Voice Guidelines
+
+The Economist's voice is authoritative but not arrogant, serious but not dull, confident but not dogmatic. Aim for clarity and directness without being preachy or casual.
+
+## The Right Register
+
+### Authoritative, Not Arrogant
+State facts and analysis with confidence. Avoid hedging unnecessarily, but don't overstate your case.
+
+**Good**: "The policy has failed"
+**Too timid**: "It could perhaps be argued that the policy may have underperformed"
+**Too arrogant**: "Only a fool would deny the policy has failed"
+
+### Serious, Not Dull
+Write about serious topics in an engaging way. Use vivid examples and concrete details.
+
+**Dull**: "Economic output declined in the third quarter"
+**Engaging**: "The economy shrank for the first time in three years, catching forecasters off guard"
+
+### Confident, Not Dogmatic
+Present your analysis clearly, but acknowledge uncertainty and opposing views where they exist.
+
+**Good**: "The evidence suggests..."
+**Dogmatic**: "There can be no doubt that..."
+**Too weak**: "Some people might possibly think..."
+
+## What to Avoid
+
+### Being Too Casual
+Avoid slang, colloquialisms, and overly informal language.
+
+| Too Casual | Better |
+|------------|--------|
+| "The economy tanked" | "The economy contracted sharply" |
+| "Politicians got into a spat" | "Politicians clashed" |
+| "It's a big deal" | "It matters greatly" |
+| "Kind of disappointing" | "Disappointing" |
+| "Basically, the problem is..." | "The problem is..." |
+
+### Being Too Chatty
+Avoid addressing the reader directly too often, or using conversational fillers.
+
+| Too Chatty | Better |
+|------------|--------|
+| "You might think that..." | "It might seem that..." |
+| "Well, it turns out..." | "In fact..." |
+| "Now, here's the thing..." | [Delete and get to the point] |
+| "So, what does this mean?" | "The implications are..." |
+
+### Being Preachy or Didactic
+Do not lecture the reader. Present analysis, not moral instruction.
+
+| Preachy | Neutral |
+|---------|---------|
+| "Governments must act now" | "The case for government action is strong" |
+| "This cannot be allowed to continue" | "This is unsustainable" |
+| "We should all recognise that..." | "The evidence shows..." |
+| "It is vital that people understand..." | [Just explain clearly] |
+
+### Being Flippant
+Avoid treating serious subjects too lightly.
+
+| Flippant | Appropriate |
+|----------|-------------|
+| "Another day, another crisis" | "The latest crisis follows several others" |
+| "Surprise, surprise" | "As expected" |
+| "Good luck with that" | "The prospects are uncertain" |
+
+## Adjectives and Adverbs
+
+### Use Restraint
+Strong writing relies on nouns and verbs, not adjectives and adverbs. Most modifiers can be cut.
+
+**Overwritten**: "The absolutely devastating economic crisis brutally crushed the already struggling middle class"
+
+**Better**: "The economic crisis hurt the middle class"
+
+### Avoid Intensifiers
+Words like "very", "really", "extremely", and "incredibly" add little.
+
+| Weak | Strong |
+|------|--------|
+| "Very important" | "Crucial" or "Important" |
+| "Really significant" | "Significant" |
+| "Extremely difficult" | "Difficult" |
+| "Incredibly successful" | "Successful" |
+
+### Avoid Evaluative Adjectives
+Let readers draw their own conclusions from the facts.
+
+| Evaluative | Neutral |
+|------------|---------|
+| "An impressive 10% growth" | "Growth of 10%" |
+| "A disappointing result" | "The result: X" |
+| "An alarming trend" | "A trend that concerns policymakers" |
+| "A brilliant strategy" | "A strategy that achieved X" |
+
+### When Adjectives Work
+Adjectives earn their place when they:
+- Add essential information: "a five-year plan", "a bilateral agreement"
+- Make meaningful distinctions: "a small firm" vs "a large firm"
+- Are specific and factual: "a 20% increase", "a Chinese company"
+
+## Irony and Humour
+
+### Use Sparingly
+The Economist can be wry, but humour should not undermine credibility.
+
+**Acceptable**: Dry observations, wordplay in headlines, subtle irony
+**Not acceptable**: Sarcasm, mockery, jokes that trivialise serious issues
+
+### Irony Risks
+- Irony can be misread, especially across cultures
+- It can seem smug or superior
+- Overuse becomes tiresome
+
+### Scare Quotes
+Use quotation marks for irony sparingly:
+- "The 'expert' opinion proved wrong"
+- "Their 'solution' created new problems"
+
+Too many scare quotes suggest the writer is sneering at everything.
+
+## Balance and Fairness
+
+### Present Opposing Views
+When covering contested issues, represent different perspectives fairly.
+
+**Good practice**:
+- "Critics argue... Supporters counter..."
+- "The government says... Opposition groups disagree..."
+- Give specific claims, not just "some people say"
+
+### Avoid Loaded Language
+Choose neutral terms when describing disputed matters.
+
+| Loaded | Neutral |
+|--------|---------|
+| "The regime" (unless describing a specific type of government) | "The government" |
+| "So-called experts" | "Experts" (or critique specifically) |
+| "Claimed" (implies doubt) | "Said" |
+| "Admitted" (implies wrongdoing) | "Said" or "acknowledged" |
+
+### Attribution Matters
+"Said" is neutral. Other verbs carry connotations:
+
+| Verb | Connotation |
+|------|-------------|
+| Said | Neutral |
+| Claimed | Implies doubt |
+| Admitted | Implies wrongdoing |
+| Revealed | Implies something hidden |
+| Insisted | Implies stubbornness |
+| Acknowledged | Implies reluctance |
+
+Use these deliberately, not carelessly.
+
+## Pronouns and Point of View
+
+### Avoid First Person
+The Economist traditionally avoids "I" and uses "we" sparingly, typically only in editorials representing the publication's view.
+
+**Avoid**: "I think...", "I believe..."
+**Better**: "The evidence suggests...", "The data show..."
+
+### Use "We" with Care
+"We" can mean:
+- The publication (acceptable in editorials)
+- A country or group (be clear about who)
+- The reader and writer together (occasionally)
+
+**Avoid**: Vague "we" that's unclear about who is meant.
+
+### Second Person
+Avoid addressing the reader as "you" except in specific contexts (guides, advice columns).
+
+## Referring to People
+
+A distinctive Economist convention:
+
+- **First mention**: full name — "Janet Yellen", "Jerome Powell"
+- **Thereafter**: honorific + surname — "Ms Yellen", "Mr Powell" (never a bare surname for a living person)
+- Use "Ms" unless the person prefers "Mrs" or "Miss"; "Dr" for medical doctors and (sparingly) academics
+- Job descriptions in apposition, lower case: "Jerome Powell, chairman of the Federal Reserve" — not "Chairman Powell"
+- The dead, historical figures and convicted criminals take bare surnames: "Napoleon", "Keynes"
+
+In articles The Economist itself avoids bylines and first person, writing "your correspondent" or "this newspaper" where a self-reference is unavoidable. For general documents, simply avoid "I".
+
+## Confidence Without Certainty
+
+### State Your Case
+Don't hedge excessively. If the evidence supports a conclusion, state it.
+
+**Too hesitant**: "It might perhaps be suggested that the policy could potentially have some negative effects"
+
+**Better**: "The policy has failed"
+
+### Acknowledge Limits
+But don't overclaim. Use appropriate qualifiers when warranted:
+- "The evidence suggests..."
+- "On balance..."
+- "The most likely explanation..."
+
+### When to Hedge
+Hedge when:
+- The evidence is genuinely uncertain
+- You're making a prediction
+- You're characterising others' views
+
+Don't hedge when:
+- The facts are clear
+- You're stating established knowledge
+- You've already made your argument
+
+## Checklist
+
+- [ ] Is the tone confident but not arrogant?
+- [ ] Are evaluative adjectives justified by evidence?
+- [ ] Are intensifiers (very, really, extremely) necessary?
+- [ ] Is the language neutral on contested issues?
+- [ ] Are opposing views fairly represented?
+- [ ] Is any humour appropriate and effective?
+- [ ] Does the piece avoid lecturing the reader?

--- a/plugins/economist-style/skills/economist-style/reference/WORDS.md
+++ b/plugins/economist-style/skills/economist-style/reference/WORDS.md
@@ -1,0 +1,47 @@
+# Usage: An A-Z of Rulings
+
+The Economist Style Guide is at heart an alphabetical list of rulings on individual words. These are the ones most often misused. Flag a word only when the text uses it in the disputed sense.
+
+| Word | Ruling |
+|------|--------|
+| address (verb) | Vague when applied to problems. Tackle, deal with, or answer |
+| aggravate | Means make worse, not annoy or irritate |
+| alibi | Proof of being elsewhere, not any excuse |
+| alternative | One of two; if more, use option or choice |
+| anticipate | Means act in expectation of, not simply expect |
+| beg the question | Means assume what is to be proved, not raise the question |
+| community | Overused ("the international community", "the business community"). Name who you mean |
+| compare | Compare with when noting differences; compare to when likening |
+| comprise | The whole comprises the parts. Never "comprised of" |
+| crisis | A decisive turning point, not any difficulty. Overused |
+| decimate | Historically to kill one in ten; avoid using loosely for destroy |
+| dilemma | A choice between two unwelcome options, not any problem |
+| disinterested | Impartial, not uninterested |
+| enormity | Great wickedness, not great size |
+| epicentre | The point on the surface above an earthquake's focus; not "the very centre" |
+| famously | If it is famous, you need not say so; if not, the word is false |
+| flaunt | To display ostentatiously. To defy a rule is to flout it |
+| fortuitous | By chance, not fortunate |
+| fulsome | Excessive and insincere (of praise), not abundant |
+| hopefully | Avoid as a sentence adverb ("Hopefully, rates will fall"). Say who hopes |
+| iconic | Overused to exhaustion. Say why the thing matters |
+| imply / infer | Speakers imply; listeners infer |
+| individual (noun) | Prefer person, man, woman |
+| key (adjective) | Overused. Important, main, chief — or cut it |
+| less / fewer | Less for quantity, fewer for number: less money, fewer coins |
+| literally | Not an intensifier. "Literally exploded" means exploded |
+| major | Overused. Big, chief, main — or cut it |
+| masterful | Domineering. A skilful performance is masterly |
+| massive | Overused for large. Reserve for physical mass |
+| may / might | Might for hypotheticals and past possibility; may for permission and present possibility |
+| militate / mitigate | Circumstances militate against; you mitigate (soften) an effect |
+| ongoing | Avoid. Continuing, or often just cut it |
+| practicable | Capable of being done; practical means useful or sensible |
+| prevaricate | To speak evasively; to delay is to procrastinate |
+| protagonist | The chief actor in a drama — there is only one |
+| refute | To disprove. If someone merely disagrees, they deny or reject |
+| situation | Usually redundant: "a crisis situation" is a crisis |
+| transpire | To become known, not to happen |
+| unique | Absolute — nothing is "very unique" or "quite unique" |
+| viable | Capable of independent life. Overused for feasible or promising |
+| whilst | Prefer while |


### PR DESCRIPTION
Adds **economist-style**, a skill-based plugin that applies The Economist style guide to written content: clarity, precision, brevity, weasel-word and cliché detection, plus house-style rules (numbers, dates, punctuation, honorifics). Dialect-aware — it matches a document's existing British/American conventions rather than forcing either.

- Pure skills: no MCP servers, hooks, scripts or external dependencies
- Rules validated against the official Economist Style Guide (11th edition)
- Source and issues: https://github.com/TAJD/economist-style-guide-plugin
- Unofficial; not affiliated with The Economist (disclaimer included in the description and README)

Vendored under `plugins/economist-style` following the repo convention, with a matching `marketplace.json` entry (category: writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131tgKBF3gYNe7aKaDmkP2j